### PR TITLE
Updated Admin and Provider registration endpoints

### DIFF
--- a/api-server/__tests__/api.test.ts
+++ b/api-server/__tests__/api.test.ts
@@ -1,132 +1,302 @@
 import request from 'supertest';
 import app from '../src/index';
 // Corrected import path for the database file
-import { applicationsDB, providerProfilesDB, providerSchemasDB } from '../src/database';
+import { applicationsDB, providerProfilesDB, providerSchemasDB, providerSubmissionsDB } from '../src/database';
 
 // Helper to reset the in-memory databases before each test
 const resetDatabases = () => {
     applicationsDB.length = 0;
     providerProfilesDB.length = 0;
     providerSchemasDB.length = 0;
+    providerSubmissionsDB.length = 0;
 };
 
 describe('API Endpoints with Standardized Responses', () => {
 
     beforeEach(() => {
-        // Reset the state of all in-memory DBs before each test
         resetDatabases();
     });
 
-    // --- Tests for Consumer Application Endpoints ---
+    // Tests for Consumer Application Endpoints
     describe('Consumer Applications', () => {
-        const validApplicationPayload = {
-            appId: "passport-app-123",
-            requiredFields: { "drp.PersonData.nic": {}, "rgd.BirthCertificate.birthDate": {} }
-        };
-
         it('GET /available-fields - should return the mock structure of available fields', async () => {
             const res = await request(app).get('/available-fields');
-            
+
             expect(res.statusCode).toEqual(200);
             expect(res.body.status).toBe('success');
             expect(res.body.data).toHaveProperty('drp');
-            expect(res.body.data).toHaveProperty('rgd');
-            expect(res.body.data.drp.types.PersonData).toBeDefined();
         });
 
         it('POST /applications - should create a new application', async () => {
-            const res = await request(app).post('/applications').send(validApplicationPayload);
+            const res = await request(app).post('/applications').send({
+                appId: "passport-app-123",
+                requiredFields: { "drp.PersonData.nic": {} }
+            });
 
             expect(res.statusCode).toEqual(201);
             expect(res.body.status).toBe('success');
             expect(res.body.data.status).toBe('pending');
-            expect(res.body.data.appId).toBe(validApplicationPayload.appId);
         });
 
-        it('POST /applications - should return a structured error if application already exists', async () => {
-            await request(app).post('/applications').send(validApplicationPayload);
-            const res = await request(app).post('/applications').send(validApplicationPayload);
-            
-            expect(res.statusCode).toEqual(409);
+        it('POST /applications with invalid payload - should return a 400 error', async () => {
+            const res = await request(app).post('/applications').send({});
+            expect(res.statusCode).toEqual(400);
             expect(res.body.status).toBe('error');
-            expect(res.body.data).toBeNull();
-            expect(res.body.error).toBeDefined();
+            expect(res.body.message).toContain('missing');
         });
     });
 
-    // --- Tests for Provider Profile Endpoints ---
-    describe('Provider Profiles [/providers]', () => {
-        const validProviderPayload = {
-            providerName: "Department of Registration of Persons",
-            contactEmail: "contact@drp.gov",
-            phoneNumber: "123456789",
-            providerType: "government" as const
+    // Tests for the Provider Onboarding Workflow
+    describe('Provider Onboarding Workflow', () => {
+        const validSubmissionPayload = {
+            providerName: "New Test Provider",
+            contactEmail: "contact@newprovider.com",
+            phoneNumber: "555-1234",
+            providerType: "business" as const
         };
 
-        it('POST /providers - should create a new provider profile', async () => {
-            const res = await request(app).post('/providers').send(validProviderPayload);
-            
-            expect(res.statusCode).toEqual(201);
+        it('POST /provider-submissions - should create a new provider submission', async () => {
+            const res = await request(app)
+                .post('/provider-submissions')
+                .send(validSubmissionPayload);
+
+            expect(res.statusCode).toEqual(202); // 202 Accepted
             expect(res.body.status).toBe('success');
-            expect(res.body.data).toHaveProperty('providerId');
+            expect(res.body.data).toHaveProperty('submissionId');
+        });
+
+        it('POST /provider-submissions/:submissionId/review (approve) - should approve a submission and create a permanent profile', async () => {
+            // Step 1: Create the submission
+            const submissionRes = await request(app).post('/provider-submissions').send(validSubmissionPayload);
+            const submissionId = submissionRes.body.data.submissionId;
+
+            // Step 2: Approve the submission
+            const reviewRes = await request(app)
+                .post(`/provider-submissions/${submissionId}/review`)
+                .send({ decision: 'approve' });
+
+            expect(reviewRes.statusCode).toEqual(200);
+            expect(reviewRes.body.status).toBe('success');
+            expect(reviewRes.body.data).toHaveProperty('providerId'); // The permanent ID
+            expect(reviewRes.body.data.providerName).toBe(validSubmissionPayload.providerName);
+        });
+
+        it('POST /provider-submissions/:submissionId/review (reject) - should reject a submission', async () => {
+            const submissionRes = await request(app).post('/provider-submissions').send(validSubmissionPayload);
+            const submissionId = submissionRes.body.data.submissionId;
+
+            const reviewRes = await request(app)
+                .post(`/provider-submissions/${submissionId}/review`)
+                .send({ decision: 'reject' });
+
+            expect(reviewRes.statusCode).toEqual(200);
+            expect(reviewRes.body.status).toBe('success');
+            expect(reviewRes.body.data.status).toBe('rejected');
+        });
+
+        it('POST /provider-submissions with invalid payload - should return a 400 error', async () => {
+            const res = await request(app)
+                .post('/provider-submissions')
+                .send({ providerName: 123 }); // Invalid type for providerName
+
+            expect(res.statusCode).toEqual(400);
+            expect(res.body.status).toBe('error');
+            expect(res.body.message).toContain('missing one or more required fields');
+        });
+
+        it('POST /provider-submissions/:submissionId/review with non-existent ID - should return a 404 error', async () => {
+            const res = await request(app)
+                .post('/provider-submissions/non-existent-id/review')
+                .send({ decision: 'approve' });
+
+            expect(res.statusCode).toEqual(404);
+            expect(res.body.status).toBe('error');
+            expect(res.body.message).toContain('not found');
         });
     });
 
-    // --- Tests for Provider Schema Endpoints ---
+    // Tests for Schema Endpoints for Approved Providers
     describe('Provider Schemas', () => {
-        let testProviderId: string;
+        let approvedProviderId: string;
 
+        // Before each test, run the full onboarding workflow to get an approved provider
         beforeEach(async () => {
-            const res = await request(app).post('/providers').send({
-                providerName: "Test Provider",
-                contactEmail: "test@provider.com",
+            const submissionRes = await request(app).post('/provider-submissions').send({
+                providerName: "Approved Test Provider",
+                contactEmail: "test@approved.com",
                 phoneNumber: "555-5555",
                 providerType: "business"
             });
-            testProviderId = res.body.data.providerId; // Access providerId from the data object
+            const submissionId = submissionRes.body.data.submissionId;
+
+            const approvalRes = await request(app)
+                .post(`/provider-submissions/${submissionId}/review`)
+                .send({ decision: 'approve' });
+
+            approvedProviderId = approvalRes.body.data.providerId;
         });
-        
+
         const createValidSchemaPayload = () => ({
             fieldConfigurations: {
                 "PersonData": {
-                    "nic": { source: 'fallback', isOwner: false, description: 'National ID Card number.' },
-                    "fullName": { source: 'authoritative', isOwner: true, description: 'The full legal name.' }
+                    "nic": { source: 'fallback', isOwner: false, description: 'National ID Card number.' }
                 }
             }
         });
 
-        it('POST /providers/:providerId/register_schema - should create a new schema submission', async () => {
+        it('POST /providers/:providerId/schemas - should create a schema for an approved provider', async () => {
             const res = await request(app)
-                .post(`/providers/${testProviderId}/register_schema`)
+                .post(`/providers/${approvedProviderId}/schemas`)
                 .send(createValidSchemaPayload());
 
             expect(res.statusCode).toEqual(201);
             expect(res.body.status).toBe('success');
-            expect(res.body.data).toHaveProperty('submissionId');
-            expect(res.body.data.providerId).toBe(testProviderId);
+            // The response should now contain providerId, not submissionId
+            expect(res.body.data).toHaveProperty('providerId');
+            expect(res.body.data.providerId).toBe(approvedProviderId);
         });
 
-        it('GET /providers/:providerId/schema - should return a specific schema', async () => {
-            await request(app).post(`/providers/${testProviderId}/register_schema`).send(createValidSchemaPayload());
-            const res = await request(app).get(`/providers/${testProviderId}/schema`);
+        it('POST /providers/:providerId/schemas with invalid provider ID - should return a 404 error', async () => {
+            const res = await request(app)
+                .post('/providers/non-existent-id/schemas')
+                .send(createValidSchemaPayload());
+
+            expect(res.statusCode).toEqual(404);
+            expect(res.body.status).toBe('error');
+            expect(res.body.message).toContain('not found');
+        });
+
+        it('POST /providers/:providerId/schemas with invalid payload - should return a 400 error', async () => {
+            const res = await request(app)
+                .post(`/providers/${approvedProviderId}/schemas`)
+                .send({ fieldConfigurations: {} });
+
+            expect(res.statusCode).toEqual(400);
+            expect(res.body.status).toBe('error');
+            expect(res.body.message).toContain('required');
+        });
+    });
+
+    // Tests for GET Endpoints
+    describe('GET Endpoints', () => {
+        it('GET /provider-schemas - should return a list of schemas', async () => {
+            const res = await request(app).get('/provider-schemas');
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.status).toBe('success');
+            expect(Array.isArray(res.body.data)).toBe(true);
+        });
+        
+        it('GET /applications - should return a list of all applications', async () => {
+            const res = await request(app).get('/applications');
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.status).toBe('success');
+            expect(Array.isArray(res.body.data)).toBe(true);
+        });
+
+        it('GET /applications?status=pending - should return only pending applications', async () => {
+            // Setup: create a pending and a non-pending application
+            await request(app).post('/applications').send({ appId: "app-pending", requiredFields: {} });
+            await request(app).post('/applications').send({ appId: "app-denied", requiredFields: {} });
+            await request(app).post('/applications/app-denied/review').send({ decision: 'deny' });
+            
+            const res = await request(app).get('/applications?status=pending');
+            
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.status).toBe('success');
+            expect(res.body.data.length).toBe(1);
+            expect(res.body.data[0].status).toBe('pending');
+        });
+    });
+
+    // Tests for Consumer Application Review
+    describe('Consumer Application Review', () => {
+        let appId: string;
+
+        beforeEach(async () => {
+            const res = await request(app).post('/applications').send({ appId: "test-app-review", requiredFields: {} });
+            appId = res.body.data.appId;
+        });
+
+        it('POST /applications/:appId/review (approve) - should approve a pending application', async () => {
+            const res = await request(app)
+                .post(`/applications/${appId}/review`)
+                .send({ decision: 'approve' });
 
             expect(res.statusCode).toEqual(200);
             expect(res.body.status).toBe('success');
-            expect(res.body.data.providerId).toEqual(testProviderId);
+            expect(res.body.data.status).toBe('approved');
         });
-        
-        it('POST /provider-schemas/:submissionId/review - should approve a pending schema', async () => {
-            const creationRes = await request(app).post(`/providers/${testProviderId}/register_schema`).send(createValidSchemaPayload());
-            const submissionId = creationRes.body.data.submissionId;
 
-            const reviewRes = await request(app)
-                .post(`/provider-schemas/${submissionId}/review`)
+        it('POST /applications/:appId/review (deny) - should deny a pending application', async () => {
+            const res = await request(app)
+                .post(`/applications/${appId}/review`)
+                .send({ decision: 'deny' });
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.status).toBe('success');
+            expect(res.body.data.status).toBe('denied');
+        });
+
+        it('POST /applications/:appId/review with non-existent appId - should return a 404 error', async () => {
+            const res = await request(app)
+                .post('/applications/non-existent-app/review')
+                .send({ decision: 'approve' });
+
+            expect(res.statusCode).toEqual(404);
+            expect(res.body.status).toBe('error');
+            expect(res.body.message).toContain('not found');
+        });
+
+        it('POST /applications/:appId/review with invalid decision - should return a 400 error', async () => {
+            const res = await request(app)
+                .post(`/applications/${appId}/review`)
+                .send({ decision: 'invalid' });
+
+            expect(res.statusCode).toEqual(400);
+            expect(res.body.status).toBe('error');
+            expect(res.body.message).toContain('Invalid decision');
+        });
+    });
+
+    // Tests for Provider Schema Review
+    describe('Provider Schema Review', () => {
+        let approvedProviderId: string;
+
+        beforeEach(async () => {
+            // Onboard a provider and create a schema
+            const submissionRes = await request(app).post('/provider-submissions').send({
+                providerName: "Approved Schema Provider",
+                contactEmail: "schema@test.com",
+                phoneNumber: "111-222-3333",
+                providerType: "business"
+            });
+            const submissionId = submissionRes.body.data.submissionId;
+            const approvalRes = await request(app).post(`/provider-submissions/${submissionId}/review`).send({ decision: 'approve' });
+            approvedProviderId = approvalRes.body.data.providerId;
+
+            await request(app).post(`/providers/${approvedProviderId}/schemas`).send({
+                fieldConfigurations: { "PersonData": { "nic": { source: 'fallback', isOwner: false, description: 'National ID Card number.' } } }
+            });
+        });
+
+        it('POST /provider-schemas/:providerId/review (approve) - should approve a pending schema', async () => {
+            const res = await request(app)
+                .post(`/provider-schemas/${approvedProviderId}/review`)
                 .send({ decision: 'approve' });
             
-            expect(reviewRes.statusCode).toEqual(200);
-            expect(reviewRes.body.status).toBe('success');
-            expect(reviewRes.body.data.status).toEqual('approved');
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.status).toBe('success');
+            expect(res.body.data.status).toBe('approved');
+        });
+
+        it('POST /provider-schemas/:providerId/review (changes_required) - should mark a pending schema for changes', async () => {
+            const res = await request(app)
+                .post(`/provider-schemas/${approvedProviderId}/review`)
+                .send({ decision: 'request_changes' });
+
+            expect(res.statusCode).toEqual(200);
+            expect(res.body.status).toBe('success');
+            expect(res.body.data.status).toBe('changes_required');
         });
     });
 });
-

--- a/api-server/src/controllers/providerController.ts
+++ b/api-server/src/controllers/providerController.ts
@@ -1,65 +1,108 @@
+
 import { Request, Response } from 'express';
 import crypto from 'crypto';
-import { providerProfilesDB, providerSchemasDB } from '../database';
+import { providerProfilesDB, providerSchemasDB, providerSubmissionsDB } from '../database';
 import { notifyAdmin, updatePdpWithProviderMetadata } from '../services';
-import { ProviderProfile, ProviderSchema, FieldConfigurations, ProviderType } from '../types';
+import { ProviderProfile, ProviderSubmission } from '../types';
 import { sendSuccess, sendError } from '../utils/responseHandler';
 
 /**
- * @summary [PROVIDER] Register a new Data Provider profile
+ * @summary [PROVIDER] Submit a registration request to become a Data Provider
+ * @description Creates a temporary submission record that awaits admin approval
+ * @route POST /provider-submissions
  */
-export const createProviderProfile = (req: Request, res: Response) => {
+export const createProviderSubmission = (req: Request, res: Response) => {
     const { providerName, contactEmail, phoneNumber, providerType } = req.body;
 
-    // Validation Logic
+    // Validation
     if (!providerName || !contactEmail || !phoneNumber || !providerType) {
         return sendError(res, 'Invalid request body: missing one or more required fields.', 400);
     }
-    const validTypes: ProviderType[] = ['government', 'board', 'business'];
-    if (!validTypes.includes(providerType)) {
-        return sendError(res, `Invalid providerType. Must be one of: ${validTypes.join(', ')}.`, 400);
-    }
-    if (providerProfilesDB.some(p => p.providerName.toLowerCase() === providerName.toLowerCase())) {
-        return sendError(res, `A provider with the name '${providerName}' already exists.`, 409);
+    if (providerSubmissionsDB.some(s => s.providerName.toLowerCase() === providerName.toLowerCase() && s.status === 'pending')) {
+        return sendError(res, `A pending submission for '${providerName}' already exists.`, 409);
     }
 
-    // Creation Logic
-    const newProvider: ProviderProfile = {
-        providerId: `prov_${crypto.randomBytes(12).toString('hex')}`,
-        providerName, contactEmail, phoneNumber, providerType,
+    // Submission Creation
+    const newSubmission: ProviderSubmission = {
+        submissionId: `sub_prov_${crypto.randomBytes(12).toString('hex')}`,
+        providerName,
+        contactEmail,
+        phoneNumber,
+        providerType,
+        status: 'pending',
         createdAt: new Date().toISOString()
     };
-    providerProfilesDB.push(newProvider);
-    
-    return sendSuccess(res, newProvider, 'Provider profile created successfully.', 201);
-};
+    providerSubmissionsDB.push(newSubmission);
+    notifyAdmin(`New provider registration for '${providerName}' requires review.`);
 
+    return sendSuccess(res, { submissionId: newSubmission.submissionId }, 'Provider registration submitted for review.', 202);
+};  
 
 /**
- * @summary [PROVIDER] Register a new, detailed data schema for an existing provider
+ * @summary [ADMIN] Get all provider submissions
  */
-export const registerSchema = (req: Request, res: Response) => {
-     if (!req.body) {
+export const getAllProviderSubmissions = (req: Request, res: Response) => {
+    return sendSuccess(res, providerSubmissionsDB, 'Provider submissions retrieved successfully.');
+};
+
+/**
+ * @summary [ADMIN] Review a provider registration submission
+ * @description Approves or rejects a pending provider registration. On approval, creates the permanent provider profile
+ * @route POST /provider-submissions/:submissionId/review
+ */
+export const reviewProviderSubmission = (req: Request, res: Response) => {
+    const { submissionId } = req.params;
+    const { decision } = req.body;
+    const submission = providerSubmissionsDB.find(s => s.submissionId === submissionId);
+
+    if (!submission) {
+        return sendError(res, `Provider submission with ID '${submissionId}' not found.`, 404);
+    }
+    if (submission.status !== 'pending') {
+        return sendError(res, `Submission is already '${submission.status}' and cannot be reviewed again.`, 409);
+    }
+
+    if (decision === 'approve') {
+        const newProvider: ProviderProfile = {
+            providerId: `prov_${crypto.randomBytes(12).toString('hex')}`,
+            providerName: submission.providerName,
+            contactEmail: submission.contactEmail,
+            phoneNumber: submission.phoneNumber,
+            providerType: submission.providerType,
+            approvedAt: new Date().toISOString()
+        };
+        providerProfilesDB.push(newProvider);
+        submission.status = 'approved'; 
+        return sendSuccess(res, newProvider, 'Provider submission approved and profile created.');
+    } else if (decision === 'reject') {
+        submission.status = 'rejected';
+        return sendSuccess(res, submission, 'Provider submission has been rejected.');
+    } else {
+        return sendError(res, "Invalid decision. Must be 'approve' or 'reject'.", 400);
+    }
+};
+
+/**
+ * @summary [PROVIDER] Create a new schema for an existing, approved provider
+ * @route POST /providers/:providerId/schemas
+ */
+export const createSchemaForProvider = (req: Request, res: Response) => {
+    const { providerId } = req.params;
+    if (!req.body) {
         return sendError(res, "Request body is missing.", 400);
     }
-    
-    const { providerId } = req.params;
     const { fieldConfigurations } = req.body;
 
-    // Validation Logic
-    if (!providerProfilesDB.some(p => p.providerId === providerId)) {
+    const provider = providerProfilesDB.find(p => p.providerId === providerId);
+    if (!provider) {
         return sendError(res, `Provider with providerId '${providerId}' not found.`, 404);
     }
     if (!fieldConfigurations || Object.keys(fieldConfigurations).length === 0) {
-        return sendError(res, "Invalid request body: 'fieldConfigurations' is required and cannot be empty.", 400);
-    }
-    if (providerSchemasDB.some(s => s.providerId === providerId && (s.status === 'pending' || s.status === 'approved'))) {
-        return sendError(res, `An active or pending schema submission for '${providerId}' already exists.`, 409);
+        return sendError(res, "Invalid request body: 'fieldConfigurations' is required.", 400);
     }
 
-    // Creation Logic
     const newSchema: ProviderSchema = {
-        submissionId: `sub_${crypto.randomBytes(12).toString('hex')}`,
+        submissionId: `sub_schema_${crypto.randomBytes(12).toString('hex')}`,
         providerId,
         status: 'pending',
         fieldConfigurations
@@ -67,7 +110,7 @@ export const registerSchema = (req: Request, res: Response) => {
     providerSchemasDB.push(newSchema);
     notifyAdmin(`New schema from provider '${providerId}' requires review.`);
 
-    return sendSuccess(res, newSchema, 'Schema submitted successfully for review.', 201);
+    return sendSuccess(res, { providerId: newSchema.providerId }, 'Schema submitted successfully for review.', 201);
 };
 
 /**
@@ -98,12 +141,12 @@ export const getAllSchemas = (req: Request, res: Response) => {
  * @summary [ADMIN] Approve or request changes for a provider's schema
  */
 export const reviewSchema = async (req: Request, res: Response) => {
-    const { submissionId } = req.params;
+    const { providerId } = req.params;
     const { decision } = req.body;
-    const schema = providerSchemasDB.find(s => s.submissionId === submissionId);
+    const schema = providerSchemasDB.find(s => s.providerId === providerId && s.status === 'pending');
 
     if (!schema) {
-        return sendError(res, `Schema submission with ID '${submissionId}' not found.`, 404);
+        return sendError(res, `Schema submission for this provider not found or is no longer pending.`, 404);
     }
     if (schema.status !== 'pending') {
         return sendError(res, `Schema is already '${schema.status}' and cannot be reviewed again.`, 409);
@@ -120,4 +163,3 @@ export const reviewSchema = async (req: Request, res: Response) => {
         return sendError(res, "Invalid decision. Must be 'approve' or 'request_changes'.", 400);
     }
 };
-

--- a/api-server/src/database.ts
+++ b/api-server/src/database.ts
@@ -1,7 +1,8 @@
-import { Application, ProviderProfile, ProviderSchema } from "./types";
+import { Application, ProviderProfile, ProviderSchema, ProviderSubmission } from "./types";
 
 // IN-MEMORY DATABASES
 // TODO: in v2, replace with persistent database like PostgreSQL
 export const applicationsDB: Application[] = [];
 export const providerProfilesDB: ProviderProfile[] = [];
 export const providerSchemasDB: ProviderSchema[] = [];
+export const providerSubmissionsDB: ProviderSubmission[] = [];

--- a/api-server/src/routes/providerRoutes.ts
+++ b/api-server/src/routes/providerRoutes.ts
@@ -1,28 +1,35 @@
 import express from 'express';
 import {
-    createProviderProfile,
-    registerSchema,
-    getSchemaForProvider,
-    getAllSchemas,
-    reviewSchema
+   createProviderSubmission,
+   reviewProviderSubmission,
+   createSchemaForProvider,
+   getSchemaForProvider,
+   getAllSchemas,
+   reviewSchema,
+   getAllProviderSubmissions
 } from '../controllers/providerController';
 
 const router = express.Router();
 
-// [PROVIDER] Register a new Data Provider profile
-router.post('/providers', createProviderProfile);
+// [PROVIDER] Submit a registration to become a Data Provider
+router.post('/provider-submissions', createProviderSubmission);
 
-// [PROVIDER] Register a new, detailed data schema for an existing provider
-router.post('/providers/:providerId/register_schema', registerSchema);
+// [ADMIN] Get all provider submissions
+router.get('/provider-submissions', getAllProviderSubmissions);
 
-// [PROVIDER & ADMIN] Get a specific provider's schema submission
+// [ADMIN] Review a provider registration submission
+router.post('/provider-submissions/:submissionId/review', reviewProviderSubmission);
+
+// [PROVIDER] Create a new schema for an existing, approved provider
+router.post('/providers/:providerId/schemas', createSchemaForProvider);
+
+// [PROVIDER & ADMIN] Get a specific provider's schema
 router.get('/providers/:providerId/schema', getSchemaForProvider);
 
-// [ADMIN] Get all provider schema submissions
+// [ADMIN] Get all provider schemas
 router.get('/provider-schemas', getAllSchemas);
 
 // [ADMIN] Approve or request changes for a provider's schema
-router.post('/provider-schemas/:submissionId/review', reviewSchema);
-
+router.post('/provider-schemas/:providerId/review', reviewSchema);
 
 export default router;

--- a/api-server/src/types/index.ts
+++ b/api-server/src/types/index.ts
@@ -17,20 +17,34 @@ export interface Application {
 // Represents the type of a data provider
 export type ProviderType = 'government' | 'board' | 'business';
 
-// Represents the approval status of a provider's profile
-export type ProviderProfileStatus = 'pending' | 'approved' | 'rejected';
+// Represents the approval status of a provider's registration
+export type ProviderSubmissionStatus = 'pending' | 'approved' | 'rejected';
 
 /**
- * Represents the core profile of a Data Provider organization
+ * @summary Represents a temporary submission from a potential new provider
+ * @description This record is created upon initial registration and awaits admin approval
  */
-export interface ProviderProfile {
-    providerId: string;
+export interface ProviderSubmission {
+    submissionId: string;
     providerName: string;
     contactEmail: string;
     phoneNumber: string;
     providerType: ProviderType;
+    status: ProviderSubmissionStatus;
     createdAt: string;
-    status: ProviderProfileStatus;
+}
+
+/**
+ * @summary Represents the official, approved profile of a Data Provider
+ * @description This record is only created after an admin approves a ProviderSubmission
+ */
+export interface ProviderProfile {
+    providerId: string; // Permanent ID generated on approval
+    providerName: string;
+    contactEmail: string;
+    phoneNumber: string;
+    providerType: ProviderType;
+    approvedAt: string;
 }
 
 // Represents the status of a data provider's schema submission


### PR DESCRIPTION
Documenting the endpoints added up til this point

Run unit tests with `npm run test`

Manual testing, first `npm run dev` to get localhost:3000 up. Test with Postman 

### Consumer Endpoints
`GET /available-fields` retrieves a list of data fields available from all approved providers

`POST /applications` submits a new application to request access to data

### Provider Endpoints
`POST /provider-submissions` submits a new registration request to become a data provider

`POST /providers/:providerId/schemas` submits a new schema for an existing, approved provider

### Admin Endpoints
`GET /applications` retrieves a list of all consumer applications. This endpoint supports an optional status query parameter (e.g., ?status=pending)

`POST /applications/:appId/review` approves or denies a specific consumer application

`GET /provider-submissions` retrieves a list of all provider registration submissions

`POST /provider-submissions/:submissionId/review` reviews and approves or rejects a provider registration submission

`GET /provider-schemas` retrieves a list of all submitted provider schemas

`POST /provider-schemas/:providerId/review` reviews and approves or requests changes for a provider's schema

### Shared Endpoints
`GET /providers/:providerId/schema` retrieves the schema for a specific provider