### PR TITLE
Small update to PDP Dockerfile to fix Choreo build

### DIFF
--- a/exchange/policy-decision-point/Dockerfile
+++ b/exchange/policy-decision-point/Dockerfile
@@ -16,12 +16,6 @@ RUN apk add --no-cache git ca-certificates tzdata
 COPY go.mod go.sum ./
 COPY . ./
 
-# Copy shared packages - for Choreo builds, shared packages should be copied into the service directory
-COPY shared/ /app/shared/
-
-# Copy local models
-COPY models/ /app/models/
-
 # Download dependencies
 RUN go mod download
 
@@ -44,9 +38,6 @@ WORKDIR /app
 
 # Copy binary from builder stage
 COPY --from=builder /app/service_binary /app/
-
-# Copy service-specific files (policies)
-COPY --from=builder /app/policies/ /app/policies/
 
 # Change ownership to appuser
 RUN chown -R appuser:appuser /app


### PR DESCRIPTION
Previously [Choreo build fail](https://console.choreo.dev/organizations/lankasoftwarefoundation/projects/opendif-ndx/components/policy-decision-point/build?buildId=20000459156) for PDP at `STEP 11/13` because the Dockerfile command `COPY models/ /app/models/` cannot find a directory named models at the root of the PDP build context

This small fix updates `policy-decision-point/Dockerfile`

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/13c3914d-bd35-4c27-8da6-a9702b249eeb" />
