### PR TITLE
WIP: 252 OE schema integration with API Server

### DIFF
--- a/api-server-go/openapi.yaml
+++ b/api-server-go/openapi.yaml
@@ -963,9 +963,10 @@ components:
       required:
         - schemaName
         - sdl
-        - endpoint
-        - memberId
       properties:
+        schemaId:
+          type: string
+          description: Optional schema ID (for unified schemas from Orchestration Engine). If not provided, auto-generated.
         schemaName:
           type: string
           description: Name of the schema
@@ -978,10 +979,13 @@ components:
           description: Schema Definition Language content
         endpoint:
           type: string
-          description: GraphQL endpoint URL
+          description: GraphQL endpoint URL (optional for unified schemas, defaults to "unified-schema")
         memberId:
           type: string
-          description: Reference to the owning member
+          description: Reference to the owning member (optional for unified schemas, defaults to "system-unified-schema")
+        version:
+          type: string
+          description: Schema version (optional, defaults to active version)
 
     UpdateSchemaRequest:
       type: object

--- a/api-server-go/v1/handlers/v1_handler_test.go
+++ b/api-server-go/v1/handlers/v1_handler_test.go
@@ -264,12 +264,13 @@ func TestSchemaEndpoints(t *testing.T) {
 	testMemberID := "test-member-id"
 
 	t.Run("POST /api/v1/schemas - CreateSchema", func(t *testing.T) {
+		endpoint := "http://example.com/graphql"
 		req := models.CreateSchemaRequest{
 			SchemaName:        "Test Schema",
 			SchemaDescription: stringPtr("Test Description"),
 			SDL:               "type Query { test: String }",
-			Endpoint:          "http://example.com/graphql",
-			MemberID:          testMemberID,
+			Endpoint:          &endpoint,
+			MemberID:          &testMemberID,
 		}
 
 		reqBody, _ := json.Marshal(req)

--- a/api-server-go/v1/models/dtos.go
+++ b/api-server-go/v1/models/dtos.go
@@ -24,12 +24,15 @@ type UpdateSchemaSubmissionRequest struct {
 }
 
 // CreateSchemaRequest creates a new provider schema
+// For unified schemas (from Orchestration Engine), schemaId, endpoint, and memberId are optional
 type CreateSchemaRequest struct {
+	SchemaID          *string `json:"schemaId,omitempty"` // Optional: if provided, used as-is (for unified schemas)
 	SchemaName        string  `json:"schemaName" validate:"required"`
 	SchemaDescription *string `json:"schemaDescription,omitempty"`
 	SDL               string  `json:"sdl" validate:"required"`
-	Endpoint          string  `json:"endpoint" validate:"required"`
-	MemberID          string  `json:"memberId" validate:"required"`
+	Endpoint          *string `json:"endpoint,omitempty"` // Optional for unified schemas
+	MemberID          *string `json:"memberId,omitempty"` // Optional for unified schemas
+	Version           *string `json:"version,omitempty"`  // Optional: version string
 }
 
 // UpdateSchemaRequest updates an existing provider schema

--- a/exchange/orchestration-engine-go/openapi.yaml
+++ b/exchange/orchestration-engine-go/openapi.yaml
@@ -5,6 +5,8 @@ info:
   description: |
     The Orchestration Engine provides GraphQL federation and unified schema management capabilities.
     It supports multiple schema versions, schema activation/deactivation, and GraphQL query routing.
+    Schemas can be loaded from API Server, local database, or config file.
+
 paths:
   /health:
     get:
@@ -12,6 +14,7 @@ paths:
       description: Returns a health check message.
       tags:
         - Health
+      security: []
       responses:
         '200':
           description: Successful health response
@@ -22,12 +25,62 @@ paths:
                 properties:
                   message:
                     type: string
-                example:
-                  message: "OpenDIF Server is Healthy!"
+                    example: "OpenDIF Server is Healthy!"
+
+  /public/graphql:
+    post:
+      summary: Execute GraphQL query
+      description: |
+        Executes a federated GraphQL query across multiple provider services.
+        Requires JWT authentication via X-JWT-Assertion header or Authorization header.
+      tags:
+        - GraphQL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                  description: GraphQL query string
+                  example: "query { personInfo { name } }"
+                variables:
+                  type: object
+                  description: GraphQL query variables
+                operationName:
+                  type: string
+                  description: Operation name
+              required:
+                - query
+      responses:
+        '200':
+          description: Successful GraphQL response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                  errors:
+                    type: array
+                    items:
+                      type: object
+        '400':
+          description: Bad request - invalid query
+        '401':
+          description: Unauthorized - missing or invalid JWT token
+        '500':
+          description: Internal server error
+
   /sdl:
     get:
       summary: Get active GraphQL SDL
-      description: Returns the currently active SDL (Schema Definition Language) string of the GraphQL API.
+      description: |
+        Returns the currently active SDL (Schema Definition Language) string from the local database.
+        Note: The unified schema is now primarily loaded from API Server at runtime.
       tags:
         - Schema Management
       responses:
@@ -40,15 +93,15 @@ paths:
                 properties:
                   sdl:
                     type: string
-                example:
-                  sdl: "type Query { hello: String }"
+                    example: "type Query { hello: String }"
         '404':
           description: No active schema found
         '503':
           description: Schema management not available - database not connected
+
     post:
       summary: Create new schema version
-      description: Creates a new version of the GraphQL schema.
+      description: Creates a new version of the GraphQL schema in the local database.
       tags:
         - Schema Management
       requestBody:
@@ -84,8 +137,6 @@ paths:
                     type: string
                   sdl:
                     type: string
-                  status:
-                    type: string
                   is_active:
                     type: boolean
                   created_at:
@@ -103,7 +154,7 @@ paths:
   /sdl/versions:
     get:
       summary: Get all schema versions
-      description: Returns a list of all schema versions.
+      description: Returns a list of all schema versions from the local database.
       tags:
         - Schema Management
       responses:
@@ -199,7 +250,7 @@ paths:
   /sdl/versions/{version}/activate:
     post:
       summary: Activate schema version
-      description: Activates a specific schema version, making it the active schema.
+      description: Activates a specific schema version in the local database, making it the active schema.
       tags:
         - Schema Management
       parameters:
@@ -225,8 +276,66 @@ paths:
           description: Schema version not found
         '503':
           description: Schema management not available - database not connected
-        '500':
-          description: Internal server error
+
+  /schemas/register:
+    post:
+      summary: Register unified schema to API Server
+      description: |
+        Registers a unified GraphQL schema to the API Server at runtime.
+        This enables dynamic schema updates without restarting the Orchestration Engine.
+        The schema will be stored in API Server with the specified schema ID (default: "unified-schema-v1").
+      tags:
+        - Schema Management
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                schemaId:
+                  type: string
+                  description: Schema ID in API Server (default: "unified-schema-v1")
+                  example: "unified-schema-v1"
+                schemaName:
+                  type: string
+                  description: Schema name (default: "Unified Schema")
+                  example: "Unified Schema"
+                sdl:
+                  type: string
+                  description: GraphQL SDL string
+                  example: "type Query { personInfo { name: String } }"
+                version:
+                  type: string
+                  description: Schema version (default: "1.0.0")
+                  example: "1.0.0"
+              required:
+                - sdl
+      responses:
+        '201':
+          description: Schema registered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schemaId:
+                    type: string
+                  schemaName:
+                    type: string
+                  sdl:
+                    type: string
+                  version:
+                    type: string
+                  memberId:
+                    type: string
+                  createdAt:
+                    type: string
+                    format: date-time
+        '400':
+          description: Invalid request or SDL syntax
+        '503':
+          description: API Server client not configured
 
 components:
   securitySchemes:
@@ -234,13 +343,15 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: JWT token for authentication
+      description: JWT token for authentication (via X-JWT-Assertion header or Authorization header)
 
 security:
   - bearerAuth: []
 
 tags:
-  - name: Schema Management
-    description: Schema versioning and management endpoints
   - name: Health
     description: Health check endpoints
+  - name: GraphQL
+    description: GraphQL federation endpoints
+  - name: Schema Management
+    description: Schema versioning and management endpoints

--- a/exchange/orchestration-engine-go/tests/schema_integration_test.go
+++ b/exchange/orchestration-engine-go/tests/schema_integration_test.go
@@ -27,7 +27,7 @@ func TestSchemaAPIEndpoints(t *testing.T) {
 	defer db.Close()
 
 	schemaService := services.NewSchemaService(db)
-	schemaHandler := handlers.NewSchemaHandler(schemaService)
+	schemaHandler := handlers.NewSchemaHandler(schemaService, nil)
 
 	// Test 1: Create schema
 	t.Run("CreateSchema", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestSchemaAPIErrorHandling(t *testing.T) {
 	defer db.Close()
 
 	schemaService := services.NewSchemaService(db)
-	schemaHandler := handlers.NewSchemaHandler(schemaService)
+	schemaHandler := handlers.NewSchemaHandler(schemaService, nil)
 
 	// Test 1: Create schema with invalid JSON
 	t.Run("CreateSchemaInvalidJSON", func(t *testing.T) {
@@ -274,7 +274,7 @@ func TestSchemaAPIErrorHandling(t *testing.T) {
 // TestSchemaAPIWithoutDatabase tests API behavior when database is not available
 func TestSchemaAPIWithoutDatabase(t *testing.T) {
 	// Create handler without database connection
-	schemaHandler := handlers.NewSchemaHandler(nil)
+	schemaHandler := handlers.NewSchemaHandler(nil, nil)
 
 	// Test 1: Create schema without database
 	t.Run("CreateSchemaWithoutDatabase", func(t *testing.T) {


### PR DESCRIPTION
closes https://github.com/ginaxu1/gov-dx-sandbox/issues/252 this PR loads unified schemas from the API Server at startup and register schemas at runtime

In OE we add new API Server Client `services/api_server_client.go` to comunicate with API Server to fetch and register schemas
- in `federator/federator.go`, updated `FederateQuery()` to load schemas in the following priority order:
1. API Server: use `UNIFIED_SCHEMA_ID` env var (default: "unified-schema-v1")
2. Database (local schema service)
3. Config file

- added new endpoint `POST /schemas/register` for register unified schemas to API Server at runtime. Request body:
  ```json
  {
    "schemaId": "unified-schema-v1",  // Optional, defaults to "unified-schema-v1"
    "schemaName": "Unified Schema",    // Optional, defaults to "Unified Schema"
    "sdl": "type Query { ... }",       // Required
    "version": "1.0.0"                  // Optional, defaults to "1.0.0"
  }
  ```
- In `api-server-go`, updated `v1/models/dtos.go` `CreateSchemaRequest` to support unified schemas and updated `v1/services/schema_service.go` `CreateSchema()` method to handle unified schemas

## Testing
1. You can create a unified schema directly via API Server:

```bash
curl -X POST http://localhost:3000/api/v1/schemas \
  -H "Content-Type: application/json" \
  -d '{
    "schemaId": "unified-schema-v1",
    "schemaName": "Unified Schema",
    "sdl": "type Query { personInfo { name: String } }",
    "version": "1.0.0"
  }'
```

2. Start OE

```bash
cd exchange/orchestration-engine-go
export API_SERVER_URL=http://localhost:3000
export UNIFIED_SCHEMA_ID=unified-schema-v1
export API_SERVER_API_KEY=your-api-key  # Optional
go run main.go
```

3. Test Schema Loading

OE will automatically load the unified schema from API Server when processing GraphQL queries. Check logs for:

```
Loaded unified schema from API Server schemaId=unified-schema-v1
```

4. Test Runtime Schema Registration

Register a new unified schema at runtime:

```bash
curl -X POST http://localhost:4000/schemas/register \
  -H "Content-Type: application/json" \
  -d '{
    "schemaId": "unified-schema-v2",
    "schemaName": "Unified Schema v2",
    "sdl": "type Query { personInfo { name: String age: Int } }",
    "version": "2.0.0"
  }'
```

Expected response:
```json
{
  "schemaId": "unified-schema-v2",
  "schemaName": "Unified Schema v2",
  "sdl": "type Query { personInfo { name: String age: Int } }",
  "version": "2.0.0",
  "memberId": "system-unified-schema",
  "endpoint": "unified-schema",
  "createdAt": "2024-01-01T00:00:00Z",
  "updatedAt": "2024-01-01T00:00:00Z"
}
```

5. Test GraphQL Query Execution

Execute a GraphQL query through OE

```bash
curl -X POST http://localhost:4000/public/graphql \
  -H "Content-Type: application/json" \
  -H "X-JWT-Assertion: your-jwt-token" \
  -d '{
    "query": "query { personInfo { name } }"
  }'
```

## Future Enhancements

1. **Schema Caching** cache unified schema in OE to reduce API Server calls
2. **Schema Versioning** support multiple versions of unified schemas
3. **Schema Validation** enhanced validation for @sourceInfo directives
4. **Webhook Support** API Server could notify OE when unified schema is updated
5. **Health Checks** add health check endpoint that verifies API Server connectivity

