### PR TITLE
261 code improvements

### DIFF
--- a/api-server-go/v1/handlers/v1_handler.go
+++ b/api-server-go/v1/handlers/v1_handler.go
@@ -44,7 +44,7 @@ func NewV1Handler(db *gorm.DB) (*V1Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create IDP provider: %w", err)
 	}
-	memberService := services.NewMemberService(db, &idpProvider)
+	memberService := services.NewMemberService(db, idpProvider)
 
 	pdpServiceURL := os.Getenv("CHOREO_PDP_CONNECTION_SERVICEURL")
 	if pdpServiceURL == "" {
@@ -301,7 +301,8 @@ func (h *V1Handler) createMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	member, err := h.memberService.CreateMember(&req)
+	// Pass request context to service for proper context propagation
+	member, err := h.memberService.CreateMember(r.Context(), &req)
 	if err != nil {
 		utils.RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -318,7 +319,8 @@ func (h *V1Handler) updateMember(w http.ResponseWriter, r *http.Request, memberI
 		return
 	}
 
-	member, err := h.memberService.UpdateMember(memberId, &req)
+	// Pass request context to service for proper context propagation
+	member, err := h.memberService.UpdateMember(r.Context(), memberId, &req)
 	if err != nil {
 		utils.RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
@@ -328,7 +330,8 @@ func (h *V1Handler) updateMember(w http.ResponseWriter, r *http.Request, memberI
 }
 
 func (h *V1Handler) getMember(w http.ResponseWriter, r *http.Request, memberId string) {
-	member, err := h.memberService.GetMember(memberId)
+	// Pass request context to service for proper context propagation
+	member, err := h.memberService.GetMember(r.Context(), memberId)
 	if err != nil {
 		utils.RespondWithError(w, http.StatusNotFound, err.Error())
 		return
@@ -337,7 +340,8 @@ func (h *V1Handler) getMember(w http.ResponseWriter, r *http.Request, memberId s
 }
 
 func (h *V1Handler) getAllMembers(w http.ResponseWriter, r *http.Request, idpUserId *string, email *string) {
-	members, err := h.memberService.GetAllMembers(idpUserId, email)
+	// Pass request context to service for proper context propagation
+	members, err := h.memberService.GetAllMembers(r.Context(), idpUserId, email)
 	if err != nil {
 		utils.RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/api-server-go/v1/handlers/v1_handler_test.go
+++ b/api-server-go/v1/handlers/v1_handler_test.go
@@ -74,7 +74,7 @@ func NewTestV1HandlerWithMockPDP(t *testing.T, db *gorm.DB) *V1Handler {
 	if err != nil {
 		t.Fatalf("Failed to create test IDP provider: %v", err)
 	}
-	memberService := services.NewMemberService(db, &idpProvider)
+	memberService := services.NewMemberService(db, idpProvider)
 
 	// For testing, we'll use a real PDPService but skip actual HTTP calls
 	// In a real test, you'd use a test HTTP server

--- a/api-server-go/v1/services/member_service.go
+++ b/api-server-go/v1/services/member_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -15,47 +16,49 @@ import (
 // MemberService handles Member-related operations
 type MemberService struct {
 	db  *gorm.DB
-	idp *idp.IdentityProviderAPI
+	idp idp.IdentityProviderAPI
 }
 
 // NewMemberService creates a new Member service
-func NewMemberService(db *gorm.DB, idp *idp.IdentityProviderAPI) *MemberService {
+func NewMemberService(db *gorm.DB, idp idp.IdentityProviderAPI) *MemberService {
 	return &MemberService{db: db, idp: idp}
 }
 
-// CreateMember creates a new Member
-func (s *MemberService) CreateMember(req *models.CreateMemberRequest) (*models.MemberResponse, error) {
-	ctx := context.Background()
-
-	// Create user in the IDP using the factory-created client
+// CreateMember creates a new Member and automatically adds them to the "OpenDIF_Member" group in the IDP.
+// This ensures all newly created members are automatically assigned to the member group.
+func (s *MemberService) CreateMember(ctx context.Context, req *models.CreateMemberRequest) (*models.MemberResponse, error) {
+	// Create user in the IDP
 	userInstance := &idp.User{
 		Email:       req.Email,
 		FirstName:   req.Name,
 		LastName:    "",
 		PhoneNumber: req.PhoneNumber,
 	}
-	createdUser, err := (*s.idp).CreateUser(ctx, userInstance)
+	createdUser, err := s.idp.CreateUser(ctx, userInstance)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user in IDP: %w", err)
 	}
 	if createdUser.Email != userInstance.Email {
-		return nil, fmt.Errorf("IDP user email mismatch")
+		return nil, fmt.Errorf("IDP user email mismatch: expected %s, got %s", userInstance.Email, createdUser.Email)
 	}
-	slog.Info("Created user in IDP", "userID", createdUser.Id)
+	slog.Info("Created user in IDP", "userID", createdUser.Id, "email", createdUser.Email)
 
-	// Add user to UserGroupMember in the IDP
-	patchGroupMember := &idp.GroupMember{
+	// Automatically add user to "OpenDIF_Member" group in the IDP
+	// This is a core requirement: all new members must be assigned to the member group
+	groupMember := &idp.GroupMember{
 		Value:   createdUser.Id,
 		Display: createdUser.Email,
 	}
-	groupId, err := (*s.idp).AddMemberToGroupByGroupName(ctx, string(models.UserGroupMember), patchGroupMember)
+	groupId, err := s.idp.AddMemberToGroupByGroupName(ctx, string(models.UserGroupMember), groupMember)
 	if err != nil {
-		deleteErr := (*s.idp).DeleteUser(ctx, createdUser.Id)
+		// Rollback: Delete the user we just created
+		deleteErr := s.idp.DeleteUser(ctx, createdUser.Id)
 		if deleteErr != nil {
-			return nil, fmt.Errorf("failed to add user to group in IDP: %w, and failed to rollback user creation in IDP: %w", err, deleteErr)
+			return nil, fmt.Errorf("failed to add user to group %s: %w, and failed to rollback user creation: %w", models.UserGroupMember, err, deleteErr)
 		}
-		return nil, fmt.Errorf("failed to add user to group in IDP: %w", err)
+		return nil, fmt.Errorf("failed to add user to group %s: %w", models.UserGroupMember, err)
 	}
+	slog.Info("Added user to group", "userID", createdUser.Id, "groupId", *groupId, "groupName", models.UserGroupMember)
 
 	// Create Member in the database
 	member := models.Member{
@@ -66,45 +69,38 @@ func (s *MemberService) CreateMember(req *models.CreateMemberRequest) (*models.M
 		IdpUserID:   createdUser.Id,
 	}
 	if dbErr := s.db.Create(&member).Error; dbErr != nil {
-		// Attempt to remove user from IDP group
-		removeFromGroupIdpErr := (*s.idp).RemoveMemberFromGroup(ctx, *groupId, createdUser.Id)
-		// Attempt to delete user from IDP, regardless of group removal result
-		rollbackUserCreationIdpErr := (*s.idp).DeleteUser(ctx, createdUser.Id)
-		// Aggregate errors
-		if removeFromGroupIdpErr != nil && rollbackUserCreationIdpErr != nil {
-			return nil, fmt.Errorf("failed to create member: %w, and failed to rollback user group addition in IDP: %w, and failed to rollback user creation in IDP: %w", dbErr, removeFromGroupIdpErr, rollbackUserCreationIdpErr)
-		} else if removeFromGroupIdpErr != nil {
-			return nil, fmt.Errorf("failed to create member: %w, and failed to rollback user group addition in IDP: %w", dbErr, removeFromGroupIdpErr)
-		} else if rollbackUserCreationIdpErr != nil {
-			return nil, fmt.Errorf("failed to create member: %w, and failed to rollback user creation in IDP: %w", dbErr, rollbackUserCreationIdpErr)
+		// Rollback: Remove user from group and delete user from IDP
+		var rollbackErrs []error
+		if removeErr := s.idp.RemoveMemberFromGroup(ctx, *groupId, createdUser.Id); removeErr != nil {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf("rollback group removal: %w", removeErr))
 		}
+		if deleteErr := s.idp.DeleteUser(ctx, createdUser.Id); deleteErr != nil {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf("rollback user deletion: %w", deleteErr))
+		}
+		if len(rollbackErrs) > 0 {
+			return nil, fmt.Errorf("failed to create member in database: %w, rollback errors: %v", dbErr, errors.Join(rollbackErrs...))
+		}
+		return nil, fmt.Errorf("failed to create member in database: %w", dbErr)
 	}
 
-	response := &models.MemberResponse{
-		MemberID:    member.MemberID,
-		IdpUserID:   member.IdpUserID,
-		Name:        member.Name,
-		Email:       member.Email,
-		PhoneNumber: member.PhoneNumber,
-		CreatedAt:   member.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   member.UpdatedAt.Format(time.RFC3339),
-	}
-
-	return response, nil
+	slog.Info("Created member successfully", "memberID", member.MemberID, "email", member.Email)
+	return s.buildMemberResponse(&member), nil
 }
 
 // UpdateMember updates an existing Member
-func (s *MemberService) UpdateMember(memberID string, req *models.UpdateMemberRequest) (*models.MemberResponse, error) {
+func (s *MemberService) UpdateMember(ctx context.Context, memberID string, req *models.UpdateMemberRequest) (*models.MemberResponse, error) {
 	var member models.Member
 	err := s.db.First(&member, "member_id = ?", memberID).Error
 	if err != nil {
 		return nil, fmt.Errorf("member not found: %w", err)
 	}
 
+	// Store original values for rollback if needed
+	originalName := member.Name
+	originalPhoneNumber := member.PhoneNumber
+
 	// Check if we need to update the IDP user
 	needsIdpUpdate := false
-	beforeUpdateName := member.Name
-	beforeUpdatePhoneNumber := member.PhoneNumber
 
 	// Update fields if provided
 	if req.Name != nil {
@@ -118,7 +114,6 @@ func (s *MemberService) UpdateMember(memberID string, req *models.UpdateMemberRe
 
 	// Update user in IDP if necessary
 	if needsIdpUpdate {
-		ctx := context.Background()
 		userInstance := &idp.User{
 			Email:       member.Email,
 			FirstName:   member.Name,
@@ -126,7 +121,7 @@ func (s *MemberService) UpdateMember(memberID string, req *models.UpdateMemberRe
 			PhoneNumber: member.PhoneNumber,
 		}
 
-		_, err := (*s.idp).UpdateUser(ctx, member.IdpUserID, userInstance)
+		_, err := s.idp.UpdateUser(ctx, member.IdpUserID, userInstance)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update user in IDP: %w", err)
 		}
@@ -134,21 +129,88 @@ func (s *MemberService) UpdateMember(memberID string, req *models.UpdateMemberRe
 		slog.Info("Updated user in IDP", "userID", member.IdpUserID)
 	}
 
+	// Update member in database
 	if err := s.db.Save(&member).Error; err != nil {
-		// Rollback IDP user update if DB operation fails (not implemented here)
-		_, err := (*s.idp).UpdateUser(context.Background(), member.IdpUserID, &idp.User{
-			Email:       member.Email,
-			FirstName:   beforeUpdateName,
-			LastName:    "",
-			PhoneNumber: beforeUpdatePhoneNumber,
-		})
-		if err != nil {
-			return nil, err
+		// Rollback IDP user update if DB operation fails
+		if needsIdpUpdate {
+			rollbackUser := &idp.User{
+				Email:       member.Email,
+				FirstName:   originalName,
+				LastName:    "",
+				PhoneNumber: originalPhoneNumber,
+			}
+			_, rollbackErr := s.idp.UpdateUser(ctx, member.IdpUserID, rollbackUser)
+			if rollbackErr != nil {
+				return nil, fmt.Errorf("failed to update member in database: %w, and failed to rollback IDP update: %w", err, rollbackErr)
+			}
+			slog.Warn("Rolled back IDP user update due to database failure", "userID", member.IdpUserID)
 		}
-		return nil, fmt.Errorf("failed to update member: %w", err)
+		return nil, fmt.Errorf("failed to update member in database: %w", err)
 	}
 
-	response := &models.MemberResponse{
+	slog.Info("Updated member successfully", "memberID", memberID)
+	return s.buildMemberResponse(&member), nil
+}
+
+// GetMember retrieves a Member by ID
+func (s *MemberService) GetMember(ctx context.Context, memberID string) (*models.MemberResponse, error) {
+	var member models.Member
+	err := s.db.Where("member_id = ?", memberID).First(&member).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch member: %w", err)
+	}
+
+	return s.buildMemberResponse(&member), nil
+}
+
+// GetAllMembers retrieves all members, optionally filtered by idpUserId or email
+func (s *MemberService) GetAllMembers(ctx context.Context, idpUserId *string, email *string) ([]models.MemberResponse, error) {
+	// Handle filtered query
+	if (idpUserId != nil && *idpUserId != "") || (email != nil && *email != "") {
+		return s.getFilteredMembers(ctx, idpUserId, email)
+	}
+
+	// Handle all members query
+	return s.getAllMembers(ctx)
+}
+
+// getFilteredMembers retrieves members filtered by idpUserId or email
+func (s *MemberService) getFilteredMembers(ctx context.Context, idpUserId *string, email *string) ([]models.MemberResponse, error) {
+	var member models.Member
+	query := s.db
+	if idpUserId != nil && *idpUserId != "" {
+		query = query.Where("idp_user_id = ?", *idpUserId)
+	}
+	if email != nil && *email != "" {
+		query = query.Where("email = ?", *email)
+	}
+	err := query.First(&member).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch member: %w", err)
+	}
+
+	return []models.MemberResponse{*s.buildMemberResponse(&member)}, nil
+}
+
+// getAllMembers retrieves all members
+func (s *MemberService) getAllMembers(ctx context.Context) ([]models.MemberResponse, error) {
+	var members []models.Member
+	err := s.db.Find(&members).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch members: %w", err)
+	}
+
+	response := make([]models.MemberResponse, len(members))
+	for i, member := range members {
+		response[i] = *s.buildMemberResponse(&member)
+	}
+
+	return response, nil
+}
+
+// buildMemberResponse converts a Member model to MemberResponse
+func (s *MemberService) buildMemberResponse(member *models.Member) *models.MemberResponse {
+	return &models.MemberResponse{
 		MemberID:    member.MemberID,
 		IdpUserID:   member.IdpUserID,
 		Name:        member.Name,
@@ -157,83 +219,4 @@ func (s *MemberService) UpdateMember(memberID string, req *models.UpdateMemberRe
 		CreatedAt:   member.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:   member.UpdatedAt.Format(time.RFC3339),
 	}
-
-	return response, nil
-}
-
-// GetMember retrieves a Member by ID
-func (s *MemberService) GetMember(memberID string) (*models.MemberResponse, error) {
-	var result struct {
-		models.Member
-	}
-	err := s.db.Table("members").
-		Where("members.member_id = ?", memberID).
-		First(&result).Error
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch member: %w", err)
-	}
-
-	response := &models.MemberResponse{
-		MemberID:    result.Member.MemberID,
-		IdpUserID:   result.Member.IdpUserID,
-		Name:        result.Member.Name,
-		Email:       result.Member.Email,
-		PhoneNumber: result.Member.PhoneNumber,
-		CreatedAt:   result.Member.CreatedAt.Format(time.RFC3339),
-		UpdatedAt:   result.Member.UpdatedAt.Format(time.RFC3339),
-	}
-
-	return response, nil
-}
-
-// GetAllMembers retrieves all members
-func (s *MemberService) GetAllMembers(idpUserId *string, email *string) ([]models.MemberResponse, error) {
-	if (idpUserId != nil && *idpUserId != "") || (email != nil && *email != "") {
-		var member models.Member
-		query := s.db.Table("members")
-		if idpUserId != nil && *idpUserId != "" {
-			query = query.Where("idp_user_id = ?", *idpUserId)
-		}
-		if email != nil && *email != "" {
-			query = query.Where("email = ?", *email)
-		}
-		err := query.First(&member).Error
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch member: %w", err)
-		}
-
-		response := []models.MemberResponse{{
-			MemberID:    member.MemberID,
-			IdpUserID:   member.IdpUserID,
-			Name:        member.Name,
-			Email:       member.Email,
-			PhoneNumber: member.PhoneNumber,
-			CreatedAt:   member.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   member.UpdatedAt.Format(time.RFC3339),
-		}}
-
-		return response, nil
-	}
-	var results []models.Member
-
-	err := s.db.Table("members").Find(&results).Error
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch members: %w", err)
-	}
-
-	response := make([]models.MemberResponse, len(results))
-	for i, result := range results {
-		response[i] = models.MemberResponse{
-			MemberID:    result.MemberID,
-			IdpUserID:   result.IdpUserID,
-			Name:        result.Name,
-			Email:       result.Email,
-			PhoneNumber: result.PhoneNumber,
-			CreatedAt:   result.CreatedAt.Format(time.RFC3339),
-			UpdatedAt:   result.UpdatedAt.Format(time.RFC3339),
-		}
-	}
-
-	return response, nil
 }


### PR DESCRIPTION
**this PR is suggested improvements to https://github.com/ginaxu1/gov-dx-sandbox/pull/281/files, note the base branch `261-add-member-to-group`**

## Files updated
- `api-server-go/v1/services/member_service.go` - complete refactor
- `api-server-go/v1/handlers/v1_handler.go` - updated to pass context

## Key changes
Updated `member_service.go` to implement automatic user group assignment and fix code review issues. All newly created members are automatically added to the "OpenDIF_Members" group in the IDP

 1. Automatic Group Assignment
All new members are automatically assigned to "OpenDIF_Members" group during creation. If group assignment fails, user creation is rolled back

2. Context Propagation
All service methods now accept `context.Context` as the first parameter for proper request cancellation, timeout support, and tracing. Handlers pass `r.Context()` to service methods

3. Code Quality Improvements
- removed unnecessary pointer dereferencing (`(*s.idp)` → `s.idp`)
- simplified error aggregation using `errors.Join()`
- extracted duplicate response building code to `buildMemberResponse()` helper
- fixed `UpdateMember` rollback logic
- refactored `GetAllMembers` into helper methods
