### PR TITLE
remove Docker Hub login step from the consent-engine workflow

### DIFF
--- a/.github/workflows/build-consent-engine.yml
+++ b/.github/workflows/build-consent-engine.yml
@@ -113,13 +113,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # ⬇️⬇️ FIX #1: ADD DOCKER HUB LOGIN ⬇️⬇️
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
fix this fail https://github.com/OpenDIF/opendif-mvp/actions/runs/19302601276
- removed Docker Hub login step (not needed; we only push to GHCR)
the publish job will: Checkout code, then log in to GHCR (using automatic GITHUB_TOKEN). Finally build and push the Docker image