### PR TITLE
re-enable unit tests for consent engine

### DIFF
--- a/.github/workflows/build-consent-engine.yml
+++ b/.github/workflows/build-consent-engine.yml
@@ -78,16 +78,15 @@ jobs:
       - name: Build application
         run: cd ${{ env.SERVICE_PATH }} && go build .
 
-      # TODO: Re-enable unit tests once they are fully implemented
-      # - name: Run unit & integration tests
-      #   env:
-      #     TEST_DB_HOST: localhost
-      #     TEST_DB_PORT: 5432
-      #     TEST_DB_USERNAME: ${{ env.TEST_DB_USER }}
-      #     TEST_DB_PASSWORD: ${{ env.TEST_DB_PASS }}
-      #     TEST_DB_DATABASE: ${{ env.TEST_DB_NAME }}
-      #     TEST_DB_SSLMODE: disable
-      #   run: cd ${{ env.SERVICE_PATH }} && go test ./... -count=1
+      - name: Run unit & integration tests
+        env:
+          TEST_DB_HOST: localhost
+          TEST_DB_PORT: 5432
+          TEST_DB_USERNAME: ${{ env.TEST_DB_USER }}
+          TEST_DB_PASSWORD: ${{ env.TEST_DB_PASS }}
+          TEST_DB_DATABASE: ${{ env.TEST_DB_NAME }}
+          TEST_DB_SSLMODE: disable
+        run: cd ${{ env.SERVICE_PATH }} && go test ./... -count=1
 
       - name: Scan repository for secrets (TruffleHog)
         uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
Now that we merged those PRs with unit tests for CE and Api Server, update yml files to run those unit tests on Github Workflow validation