### PR TITLE
266 handler wrapper

### DIFF
--- a/api-server-go/v1/middleware/audit_middleware_test.go
+++ b/api-server-go/v1/middleware/audit_middleware_test.go
@@ -1,10 +1,13 @@
 package middleware
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestAuditMiddleware_Initialization(t *testing.T) {
@@ -35,43 +38,165 @@ func TestAuditMiddleware_Initialization(t *testing.T) {
 	}
 }
 
-func TestLogAuditEvent_GlobalFunction(t *testing.T) {
-	// Reset global state for this test
+func TestWithAudit_InjectsAuditInfo(t *testing.T) {
+	// Reset global state
 	ResetGlobalAuditMiddleware()
+	mw := NewAuditMiddleware("http://localhost:3001")
 
-	// Initialize global audit middleware
-	_ = NewAuditMiddleware("http://localhost:3001")
+	// Create a handler that checks for AuditInfo
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auditInfo := GetAuditInfo(r.Context())
+		if auditInfo == nil {
+			t.Error("Expected AuditInfo to be injected into context")
+			return
+		}
+		
+		// Verify we can set resource ID
+		auditInfo.SetResourceID("test-resource-id")
+		
+		// Verify it persists
+		if auditInfo.ResourceID != "test-resource-id" {
+			t.Error("Expected ResourceID to be set")
+		}
+		
+		w.WriteHeader(http.StatusOK)
+	})
 
-	// Test that LogAuditEvent doesn't panic when called
+	// Wrap with middleware
+	wrappedHandler := mw.WithAudit("TEST_RESOURCE")(handler)
+
+	// Create request
+	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
+	req.Header.Set("X-User-ID", "test-user")
+	w := httptest.NewRecorder()
+
+	// Execute
+	wrappedHandler.ServeHTTP(w, req)
+}
+
+func TestWithAudit_SkipsReadOperations(t *testing.T) {
+	// Reset global state
+	ResetGlobalAuditMiddleware()
+	mw := NewAuditMiddleware("http://localhost:3001")
+
+	// Create a handler that checks for AuditInfo (should NOT be present for GET)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auditInfo := GetAuditInfo(r.Context())
+		if auditInfo != nil {
+			t.Error("Expected AuditInfo NOT to be injected for GET request")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap with middleware
+	wrappedHandler := mw.WithAudit("TEST_RESOURCE")(handler)
+
+	// Create GET request
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	w := httptest.NewRecorder()
+
+	// Execute
+	wrappedHandler.ServeHTTP(w, req)
+}
+
+func TestGetAuditInfo_NilContext(t *testing.T) {
+	info := GetAuditInfo(nil)
+	if info != nil {
+		t.Error("Expected nil AuditInfo for nil context")
+	}
+}
+
+func TestGetAuditInfo_NoAuditInfo(t *testing.T) {
+	ctx := context.Background()
+	info := GetAuditInfo(ctx)
+	if info != nil {
+		t.Error("Expected nil AuditInfo for context without audit info")
+	}
+}
+
+// TestCreateRequest_AuditLogging verifies that a CREATE request triggers the audit logic.
+// Since we can't easily mock the internal http client of the middleware without refactoring,
+// we verify that the middleware runs without panic and the context injection works as expected.
+// In a real integration test, we would point the audit URL to a mock server.
+func TestCreateRequest_AuditLogging(t *testing.T) {
+	// Reset global state
+	ResetGlobalAuditMiddleware()
+	
+	// Setup a mock audit service server to verify the request is sent
+	auditServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method and path
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST request to audit service, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/events" {
+			t.Errorf("Expected path /api/events, got %s", r.URL.Path)
+		}
+
+		// Decode body
+		var event ManagementEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Errorf("Failed to decode audit event: %v", err)
+			return
+		}
+
+		// Verify event details
+		if event.EventType != "CREATE" {
+			t.Errorf("Expected EventType CREATE, got %s", event.EventType)
+		}
+		if event.Target.Resource != "TEST_RESOURCE" {
+			t.Errorf("Expected Resource TEST_RESOURCE, got %s", event.Target.Resource)
+		}
+		if event.Target.ResourceID != "created-id-123" {
+			t.Errorf("Expected ResourceID created-id-123, got %s", event.Target.ResourceID)
+		}
+		if event.Actor.ID == nil || *event.Actor.ID != "test-user" {
+			t.Errorf("Expected Actor ID test-user, got %v", event.Actor.ID)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer auditServer.Close()
+
+	// Initialize middleware with mock server URL
+	mw := NewAuditMiddleware(auditServer.URL)
+
+	// Create a handler that simulates a CREATE operation
+	createHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 1. Retrieve AuditInfo
+		auditInfo := GetAuditInfo(r.Context())
+		if auditInfo == nil {
+			t.Error("AuditInfo not found in context")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// 2. Simulate creating a resource
+		newID := "created-id-123"
+
+		// 3. Set the resource ID in AuditInfo
+		auditInfo.SetResourceID(newID)
+
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	// Wrap with middleware
+	wrappedHandler := mw.WithAudit("TEST_RESOURCE")(createHandler)
+
+	// Create POST request
 	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
 	req.Header.Set("X-User-ID", "test-user")
 	req.Header.Set("X-User-Role", "ADMIN")
+	w := httptest.NewRecorder()
 
-	// This should not panic even if the audit service is not available
-	LogAuditEvent(req, "TEST_RESOURCE", "test-id-123")
-}
+	// Execute
+	wrappedHandler.ServeHTTP(w, req)
 
-func TestLogAudit_SkipsReadOperations(t *testing.T) {
-	auditMiddleware := NewAuditMiddleware("http://localhost:3001")
+	// Wait a bit for the goroutine to finish (since logManagementEvent is async)
+	time.Sleep(100 * time.Millisecond)
 
-	// GET request should be skipped
-	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
-	auditMiddleware.LogAudit(req, "TEST_RESOURCE", "test-id")
-
-	// This test passes if no panic occurs - we can't easily test HTTP calls without a mock server
-}
-
-func TestLogAudit_ProcessesWriteOperations(t *testing.T) {
-	auditMiddleware := NewAuditMiddleware("http://localhost:3001")
-
-	// POST request should be processed (though it may fail to send)
-	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
-	req.Header.Set("X-User-ID", "test-user")
-	req.Header.Set("X-User-Role", "MEMBER")
-
-	auditMiddleware.LogAudit(req, "TEST_RESOURCE", "test-id")
-
-	// This test passes if no panic occurs - we can't easily test HTTP calls without a mock server
+	if w.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d", w.Code)
+	}
 }
 
 func TestAuditMiddleware_ThreadSafety(t *testing.T) {
@@ -113,25 +238,4 @@ func TestAuditMiddleware_ThreadSafety(t *testing.T) {
 	if globalAuditMiddleware == nil {
 		t.Error("Expected global audit middleware to be set")
 	}
-
-	// Test that LogAuditEvent works with the global instance
-	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
-	req.Header.Set("X-User-ID", "test-user")
-	req.Header.Set("X-User-Role", "ADMIN")
-
-	// This should not panic
-	LogAuditEvent(req, "TEST_RESOURCE", "test-id-concurrent")
-}
-
-func TestLogAuditEvent_WithoutInitialization(t *testing.T) {
-	// Reset global state to ensure no global instance
-	ResetGlobalAuditMiddleware()
-
-	// Test LogAuditEvent when global middleware is not initialized
-	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
-	req.Header.Set("X-User-ID", "test-user")
-	req.Header.Set("X-User-Role", "ADMIN")
-
-	// This should not panic and should log a warning
-	LogAuditEvent(req, "TEST_RESOURCE", "test-id-no-init")
 }

--- a/audit-service/handlers/audit.go
+++ b/audit-service/handlers/audit.go
@@ -123,8 +123,14 @@ func (h *AuditHandler) CreateDataExchangeEvent(w http.ResponseWriter, r *http.Re
 	}
 
 	// ConsumerID and ProviderID are optional now (can be looked up later or tracked via ApplicationID)
-	// if req.ConsumerID == "" { ... }
-	// if req.ProviderID == "" { ... }
+	if req.ConsumerID == "" {
+		http.Error(w, "Missing required field: consumerId (member ID who owns the consumer application)", http.StatusBadRequest)
+		return
+	}
+	if req.ProviderID == "" {
+		http.Error(w, "Missing required field: providerId (member ID who owns the provider schema)", http.StatusBadRequest)
+		return
+	}
 
 	if req.Status == "" {
 		http.Error(w, "Missing required field: status", http.StatusBadRequest)


### PR DESCRIPTION
Instead of no middleware for `api-server-go` connection with `audit-service`, add context-updating handler Wrapper middleware. This centralizes audit logic so that every CUD operation is consistently logged without boilerplate in every handler. Also eliminates the risk of developers forgetting to log events while still allowing handlers to provide precise resource IDs via the request context.

## changes made 
- `WithAudit` middleware: Wraps handlers, injects `AuditInfo` into the context, and automatically logs events after execution
- Context Integration: updated handlers to set the created/modified `ResourceID` in the context
- Verification: added robust tests to confirm CREATE events are correctly captured