### PR TITLE
CE Refactor Part 2: create Services package and update main.go

### DIFF
--- a/.github/workflows/consent-engine-validate.yml
+++ b/.github/workflows/consent-engine-validate.yml
@@ -69,15 +69,15 @@ jobs:
       - name: Build application
         run: cd ${{ env.SERVICE_PATH }} && go build .
 
-      # - name: Run unit & integration tests
-      #   env:
-      #     TEST_DB_HOST: localhost
-      #     TEST_DB_PORT: 5432
-      #     TEST_DB_USERNAME: ${{ env.TEST_DB_USER }}
-      #     TEST_DB_PASSWORD: ${{ env.TEST_DB_PASS }}
-      #     TEST_DB_DATABASE: ${{ env.TEST_DB_NAME }}
-      #     TEST_DB_SSLMODE: disable
-      #   run: cd ${{ env.SERVICE_PATH }} && go test ./... -count=1
+      - name: Run unit & integration tests
+        env:
+          TEST_DB_HOST: localhost
+          TEST_DB_PORT: 5432
+          TEST_DB_USERNAME: ${{ env.TEST_DB_USER }}
+          TEST_DB_PASSWORD: ${{ env.TEST_DB_PASS }}
+          TEST_DB_DATABASE: ${{ env.TEST_DB_NAME }}
+          TEST_DB_SSLMODE: disable
+        run: cd ${{ env.SERVICE_PATH }} && go test ./... -count=1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/exchange/consent-engine/main.go
+++ b/exchange/consent-engine/main.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gov-dx-sandbox/exchange/consent-engine/v1/models"
-	service "github.com/gov-dx-sandbox/exchange/consent-engine/v1/services"
 	"github.com/gov-dx-sandbox/exchange/shared/config"
 	"github.com/gov-dx-sandbox/exchange/shared/constants"
 	"github.com/gov-dx-sandbox/exchange/shared/utils"
@@ -110,12 +108,12 @@ type TokenInfo struct {
 }
 
 // User authentication middleware that handles user JWT authentication only
-func userAuthMiddleware(userJWTVerifier *JWTVerifier, engine service.ConsentEngine, userTokenConfig UserTokenValidationConfig) func(http.Handler) http.Handler {
+func userAuthMiddleware(userJWTVerifier *JWTVerifier, engine ConsentEngine, userTokenConfig UserTokenValidationConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Extract consent ID from the URL path
 			// Handle both /consents/{id} and /consents/{id}/ patterns
-			path := strings.TrimPrefix(r.URL.Path, "/v1/consents")
+			path := strings.TrimPrefix(r.URL.Path, "/consents")
 			path = strings.TrimPrefix(path, "/")
 			if path == "" {
 				utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: "Consent ID is required"})
@@ -207,7 +205,7 @@ func userAuthMiddleware(userJWTVerifier *JWTVerifier, engine service.ConsentEngi
 }
 
 // selectiveAuthMiddleware applies authentication only to specific HTTP methods
-func selectiveAuthMiddleware(userJWTVerifier *JWTVerifier, engine service.ConsentEngine, userTokenConfig UserTokenValidationConfig, requireAuthMethods []string) func(http.Handler) http.Handler {
+func selectiveAuthMiddleware(userJWTVerifier *JWTVerifier, engine ConsentEngine, userTokenConfig UserTokenValidationConfig, requireAuthMethods []string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Check if this method requires authentication
@@ -234,7 +232,7 @@ func selectiveAuthMiddleware(userJWTVerifier *JWTVerifier, engine service.Consen
 
 // apiServer holds dependencies for the HTTP handlers
 type apiServer struct {
-	engine service.ConsentEngine
+	engine ConsentEngine
 }
 
 // Consent handlers - organized for better readability
@@ -245,7 +243,7 @@ func (s *apiServer) handleConsentPost(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *apiServer) createConsent(w http.ResponseWriter, r *http.Request) {
-	var req models.ConsentRequest
+	var req ConsentRequest
 
 	// Parse request body
 	body, err := utils.ReadRequestBody(r)
@@ -311,9 +309,9 @@ func (s *apiServer) createConsent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *apiServer) updateConsent(w http.ResponseWriter, r *http.Request) {
-	var req models.UpdateConsentRequest
+	var req UpdateConsentRequest
 	utils.JSONHandler(w, r, &req, func() (interface{}, int, error) {
-		id, err := utils.ExtractIDFromPath(r, "/v1/consents/")
+		id, err := utils.ExtractIDFromPath(r, "/consents/")
 		if err != nil {
 			return nil, http.StatusBadRequest, err
 		}
@@ -323,7 +321,7 @@ func (s *apiServer) updateConsent(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(err.Error(), "not found") {
 				return nil, http.StatusNotFound, err
 			}
-			return nil, http.StatusInternalServerError, fmt.Errorf(string(models.ErrConsentUpdateFailed)+": %w", err)
+			return nil, http.StatusInternalServerError, fmt.Errorf(ErrConsentUpdateFailed+": %w", err)
 		}
 
 		// Return simplified response format
@@ -335,7 +333,7 @@ func (s *apiServer) updateConsent(w http.ResponseWriter, r *http.Request) {
 func (s *apiServer) revokeConsent(w http.ResponseWriter, r *http.Request) {
 	var req struct{ Reason string }
 	utils.JSONHandler(w, r, &req, func() (interface{}, int, error) {
-		id, err := utils.ExtractIDFromPath(r, "/v1/consents/")
+		id, err := utils.ExtractIDFromPath(r, "/consents/")
 		if err != nil {
 			return nil, http.StatusBadRequest, err
 		}
@@ -345,7 +343,7 @@ func (s *apiServer) revokeConsent(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(err.Error(), "not found") {
 				return nil, http.StatusNotFound, err
 			}
-			return nil, http.StatusInternalServerError, fmt.Errorf(string(models.ErrConsentRevokeFailed)+": %w", err)
+			return nil, http.StatusInternalServerError, fmt.Errorf(ErrConsentRevokeFailed+": %w", err)
 		}
 		return record, http.StatusOK, nil
 	})
@@ -402,35 +400,27 @@ func (s *apiServer) patchConsentByID(w http.ResponseWriter, r *http.Request, con
 	}
 
 	// Apply partial updates
-	updatedBy := existingRecord.OwnerID
-	updateReq := models.UpdateConsentRequest{
-		Status:    models.ConsentStatus(existingRecord.Status), // Keep existing status by default
-		UpdatedBy: &updatedBy,                                  // Keep existing updated_by by default
-		Reason:    nil,                                         // Will be set if provided
+	updateReq := UpdateConsentRequest{
+		Status:    ConsentStatus(existingRecord.Status), // Keep existing status by default
+		UpdatedBy: existingRecord.OwnerID,               // Keep existing updated_by by default
+		Reason:    "",                                   // Will be set if provided
 	}
 
 	// Update only provided fields
 	if req.Status != "" {
-		updateReq.Status = models.ConsentStatus(req.Status)
+		updateReq.Status = ConsentStatus(req.Status)
 	}
 	if req.UpdatedBy != "" {
-		updateReq.UpdatedBy = &req.UpdatedBy
+		updateReq.UpdatedBy = req.UpdatedBy
 	}
 	if req.Reason != "" {
-		updateReq.Reason = &req.Reason
+		updateReq.Reason = req.Reason
 	}
 	if req.GrantDuration != "" {
-		updateReq.GrantDuration = &req.GrantDuration
+		updateReq.GrantDuration = req.GrantDuration
 	}
 	if len(req.Fields) > 0 {
-		// Convert []string to []models.ConsentField
-		fields := make([]models.ConsentField, len(req.Fields))
-		for i, fieldName := range req.Fields {
-			fields[i] = models.ConsentField{
-				FieldName: fieldName,
-			}
-		}
-		updateReq.Fields = &fields
+		updateReq.Fields = req.Fields
 	}
 
 	// Update the record
@@ -443,7 +433,7 @@ func (s *apiServer) patchConsentByID(w http.ResponseWriter, r *http.Request, con
 		}
 		return
 	}
-	slog.Info("Consent record updated", "consent_id", updatedRecord.ConsentID, "owner_id", updatedRecord.OwnerID, "owner_email", updatedRecord.OwnerEmail, "app_id", updatedRecord.AppID, "status", updatedRecord.Status, "type", updatedRecord.Type, "created_at", updatedRecord.CreatedAt, "updated_at", updatedRecord.UpdatedAt, "pending_expires_at", updatedRecord.PendingExpiresAt, "grant_expires_at", updatedRecord.GrantExpiresAt, "grant_duration", updatedRecord.GrantDuration, "fields", updatedRecord.Fields, "session_id", updatedRecord.SessionID, "consent_portal_url", updatedRecord.ConsentPortalURL)
+	slog.Info("Consent record updated", "consent_id", updatedRecord.ConsentID, "owner_id", updatedRecord.OwnerID, "owner_email", updatedRecord.OwnerEmail, "app_id", updatedRecord.AppID, "status", updatedRecord.Status, "type", updatedRecord.Type, "created_at", updatedRecord.CreatedAt, "updated_at", updatedRecord.UpdatedAt, "expires_at", updatedRecord.ExpiresAt, "grant_duration", updatedRecord.GrantDuration, "fields", updatedRecord.Fields, "session_id", updatedRecord.SessionID, "consent_portal_url", updatedRecord.ConsentPortalURL)
 
 	// Return simplified response format
 	response := updatedRecord.ToConsentResponse()
@@ -451,10 +441,10 @@ func (s *apiServer) patchConsentByID(w http.ResponseWriter, r *http.Request, con
 }
 
 func (s *apiServer) getConsentsByDataOwner(w http.ResponseWriter, r *http.Request) {
-	utils.PathHandler(w, r, "/v1/data-owner/", func(dataOwner string) (interface{}, int, error) {
+	utils.PathHandler(w, r, "/data-owner/", func(dataOwner string) (interface{}, int, error) {
 		records, err := s.engine.GetConsentsByDataOwner(dataOwner)
 		if err != nil {
-			return nil, http.StatusInternalServerError, fmt.Errorf(string(models.ErrConsentGetFailed)+": %w", err)
+			return nil, http.StatusInternalServerError, fmt.Errorf(ErrConsentGetFailed+": %w", err)
 		}
 		return map[string]interface{}{
 			"owner_id": dataOwner,
@@ -465,10 +455,10 @@ func (s *apiServer) getConsentsByDataOwner(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *apiServer) getConsentsByConsumer(w http.ResponseWriter, r *http.Request) {
-	utils.PathHandler(w, r, "/v1/consumer/", func(consumer string) (interface{}, int, error) {
+	utils.PathHandler(w, r, "/consumer/", func(consumer string) (interface{}, int, error) {
 		records, err := s.engine.GetConsentsByConsumer(consumer)
 		if err != nil {
-			return nil, http.StatusInternalServerError, fmt.Errorf(string(models.ErrConsentGetFailed)+": %w", err)
+			return nil, http.StatusInternalServerError, fmt.Errorf(ErrConsentGetFailed+": %w", err)
 		}
 		return map[string]interface{}{
 			"consumer": consumer,
@@ -482,17 +472,17 @@ func (s *apiServer) checkConsentExpiry(w http.ResponseWriter, r *http.Request) {
 	utils.GenericHandler(w, r, func() (interface{}, int, error) {
 		expiredRecords, err := s.engine.CheckConsentExpiry()
 		if err != nil {
-			return nil, http.StatusInternalServerError, fmt.Errorf(string(models.ErrConsentExpiryFailed)+": %w", err)
+			return nil, http.StatusInternalServerError, fmt.Errorf(ErrConsentExpiryFailed+": %w", err)
 		}
 
 		// Log the operation
 		slog.Info("Operation successful",
-			"operation", models.OpCheckConsentExpiry,
+			"operation", OpCheckConsentExpiry,
 			"expired_count", len(expiredRecords),
 		)
 
 		// Ensure expired_records is always an array, never null
-		expiredRecordsList := make([]*models.ConsentRecord, 0)
+		expiredRecordsList := make([]*ConsentRecord, 0)
 		if expiredRecords != nil {
 			expiredRecordsList = expiredRecords
 		}
@@ -507,7 +497,7 @@ func (s *apiServer) checkConsentExpiry(w http.ResponseWriter, r *http.Request) {
 
 // Route handlers - organized for better readability
 func (s *apiServer) consentHandler(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/v1/consents")
+	path := strings.TrimPrefix(r.URL.Path, "/consents")
 	switch {
 	case path == "" && r.Method == http.MethodPost:
 		// POST /consents - create new consent record
@@ -519,7 +509,7 @@ func (s *apiServer) consentHandler(w http.ResponseWriter, r *http.Request) {
 
 // consentHandlerWithID handles operations on /consents/{id} with different auth requirements
 func (s *apiServer) consentHandlerWithID(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/v1/consents")
+	path := strings.TrimPrefix(r.URL.Path, "/consents")
 	switch {
 	case strings.HasPrefix(path, "/") && r.Method == http.MethodGet:
 		// GET /consents/{id} - get consent by ID (requires auth)
@@ -613,7 +603,7 @@ func (s *apiServer) updateConsentByID(w http.ResponseWriter, r *http.Request, co
 	}
 
 	// Validate status if provided
-	var newStatus models.ConsentStatus
+	var newStatus ConsentStatus
 	if req.Status != "" {
 		// Validate that the status is one of the valid consent statuses
 		validStatuses := []string{"pending", "approved", "rejected", "expired", "revoked"}
@@ -628,25 +618,25 @@ func (s *apiServer) updateConsentByID(w http.ResponseWriter, r *http.Request, co
 			utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: "status must be one of: pending, approved, rejected, expired, revoked"})
 			return
 		}
-		newStatus = models.ConsentStatus(req.Status)
+		newStatus = ConsentStatus(req.Status)
 	} else {
 		// Keep existing status if not provided
-		newStatus = models.ConsentStatus(existingRecord.Status)
+		newStatus = ConsentStatus(existingRecord.Status)
 	}
 
 	// Set default reason if not provided
 	reason := req.Reason
 	if reason == "" {
 		switch newStatus {
-		case models.StatusApproved:
+		case StatusApproved:
 			reason = "Consent approved via API"
-		case models.StatusRejected:
+		case StatusRejected:
 			reason = "Consent rejected via API"
-		case models.StatusExpired:
+		case StatusExpired:
 			reason = "Consent expired via API"
-		case models.StatusRevoked:
+		case StatusRevoked:
 			reason = "Consent revoked via API"
-		case models.StatusPending:
+		case StatusPending:
 			reason = "Consent reset to pending via API"
 		default:
 			reason = "Consent updated via API"
@@ -654,17 +644,11 @@ func (s *apiServer) updateConsentByID(w http.ResponseWriter, r *http.Request, co
 	}
 
 	// Update the record
-	updatedBy := existingRecord.OwnerID
-	reasonPtr := &reason
-	var grantDurationPtr *string
-	if req.GrantDuration != "" {
-		grantDurationPtr = &req.GrantDuration
-	}
-	updateReq := models.UpdateConsentRequest{
+	updateReq := UpdateConsentRequest{
 		Status:        newStatus,
-		UpdatedBy:     &updatedBy, // Use existing owner ID
-		Reason:        reasonPtr,
-		GrantDuration: grantDurationPtr,
+		UpdatedBy:     existingRecord.OwnerID, // Use existing owner ID
+		Reason:        reason,
+		GrantDuration: req.GrantDuration, // Will be empty string if not provided
 	}
 
 	updatedRecord, err := s.engine.UpdateConsent(consentID, updateReq)
@@ -686,7 +670,7 @@ func (s *apiServer) updateConsentByID(w http.ResponseWriter, r *http.Request, co
 }
 
 func (s *apiServer) dataInfoHandler(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/v1/data-info/")
+	path := strings.TrimPrefix(r.URL.Path, "/data-info/")
 	if path == "" {
 		utils.RespondWithJSON(w, http.StatusBadRequest, utils.ErrorResponse{Error: "Consent ID is required"})
 		return
@@ -700,7 +684,7 @@ func (s *apiServer) dataInfoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *apiServer) adminHandler(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/v1/admin")
+	path := strings.TrimPrefix(r.URL.Path, "/admin")
 	if path == "/expiry-check" && r.Method == http.MethodPost {
 		s.checkConsentExpiry(w, r)
 	} else {
@@ -725,8 +709,8 @@ func main() {
 	slog.Info("--- !!! DEBUG INFO !!! --- The application is configured with ASGARDEO_JWKS_URL", "jwks_url", jwksURL)
 
 	// Initialize database connection
-	dbConfig := service.NewDatabaseConfig()
-	db, err := service.ConnectDB(dbConfig)
+	dbConfig := NewDatabaseConfig()
+	db, err := ConnectDB(dbConfig)
 	if err != nil {
 		slog.Error("Failed to connect to database", "error", err)
 		os.Exit(1)
@@ -734,7 +718,7 @@ func main() {
 	defer db.Close()
 
 	// Initialize database tables
-	if err := service.InitDatabase(db); err != nil {
+	if err := InitDatabase(db); err != nil {
 		slog.Error("Failed to initialize database", "error", err)
 		os.Exit(1)
 	}
@@ -744,7 +728,7 @@ func main() {
 
 	slog.Info("Using consent portal URL", "url", consentPortalUrl)
 
-	engine := service.NewPostgresConsentEngine(db, consentPortalUrl)
+	engine := NewPostgresConsentEngine(db, consentPortalUrl)
 	server := &apiServer{engine: engine}
 
 	// Start background expiry process with context cancellation
@@ -799,15 +783,15 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Routes that don't require authentication
-	mux.Handle("/v1/consents", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.consentHandler)))
-	mux.Handle("/v1/data-owner/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.dataOwnerHandler)))
-	mux.Handle("/v1/consumer/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.consumerHandler)))
-	mux.Handle("/v1/admin/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.adminHandler)))
-	mux.Handle("/v1/data-info/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.dataInfoHandler)))
-	mux.Handle("/v1/health", utils.PanicRecoveryMiddleware(utils.HealthHandler("consent-engine")))
+	mux.Handle("/consents", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.consentHandler)))
+	mux.Handle("/data-owner/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.dataOwnerHandler)))
+	mux.Handle("/consumer/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.consumerHandler)))
+	mux.Handle("/admin/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.adminHandler)))
+	mux.Handle("/data-info/", utils.PanicRecoveryMiddleware(http.HandlerFunc(server.dataInfoHandler)))
+	mux.Handle("/health", utils.PanicRecoveryMiddleware(utils.HealthHandler("consent-engine")))
 
 	// Routes for /consents/{id} with selective authentication (GET and PUT require auth, PATCH and DELETE don't)
-	mux.Handle("/v1/consents/", utils.PanicRecoveryMiddleware(selectiveAuthMiddleware(userJWTVerifier, engine, userTokenConfig, []string{"GET", "PUT"})(http.HandlerFunc(server.consentHandlerWithID))))
+	mux.Handle("/consents/", utils.PanicRecoveryMiddleware(selectiveAuthMiddleware(userJWTVerifier, engine, userTokenConfig, []string{"GET", "PUT"})(http.HandlerFunc(server.consentHandlerWithID))))
 
 	// Create server using utils
 	serverConfig := &utils.ServerConfig{

--- a/exchange/consent-engine/test_utils.go
+++ b/exchange/consent-engine/test_utils.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// TestEngineType represents the type of engine to use for testing
+type TestEngineType int
+
+const (
+	InMemoryEngine TestEngineType = iota
+	PostgresEngine
+)
+
+// SetupTestEngine creates a test engine based on environment configuration
+func SetupTestEngine(t *testing.T) ConsentEngine {
+	// Check if we should use PostgreSQL for testing
+	usePostgres := os.Getenv("TEST_USE_POSTGRES") == "true"
+
+	if usePostgres {
+		return setupPostgresTestEngine(t)
+	}
+
+	// Default to PostgreSQL engine for tests
+	return setupPostgresTestEngine(t)
+}
+
+// setupPostgresTestEngine creates a PostgreSQL test engine
+func setupPostgresTestEngine(t *testing.T) ConsentEngine {
+	return setupPostgresTestEngineWithDB(t).engine
+}
+
+// postgresTestEngineWithDB holds both the engine and database connection for tests
+type postgresTestEngineWithDB struct {
+	engine ConsentEngine
+	db     *sql.DB
+}
+
+// setupPostgresTestEngineWithDB creates a PostgreSQL test engine and returns both engine and DB
+func setupPostgresTestEngineWithDB(t *testing.T) *postgresTestEngineWithDB {
+	// Use test database configuration
+	config := &DatabaseConfig{
+		Host:            getEnvOrDefault("TEST_DB_HOST", "localhost"),
+		Port:            getEnvOrDefault("TEST_DB_PORT", "5432"),
+		Username:        getEnvOrDefault("TEST_DB_USERNAME", "postgres"),
+		Password:        getEnvOrDefault("TEST_DB_PASSWORD", "password"),
+		Database:        getEnvOrDefault("TEST_DB_DATABASE", "consent_engine_test"),
+		SSLMode:         getEnvOrDefault("TEST_DB_SSLMODE", "disable"),
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: 5 * time.Minute,
+		ConnMaxIdleTime: 1 * time.Minute,
+		QueryTimeout:    30 * time.Second,
+		ConnectTimeout:  10 * time.Second,
+		RetryAttempts:   3,
+		RetryDelay:      1 * time.Second,
+	}
+
+	db, err := ConnectDB(config)
+	if err != nil {
+		t.Skipf("Skipping PostgreSQL test: failed to connect to database: %v", err)
+	}
+
+	// Initialize database tables
+	if err := InitDatabase(db); err != nil {
+		t.Fatalf("Failed to initialize test database: %v", err)
+	}
+
+	// Clean up test data before each test
+	cleanupTestData(t, db)
+
+	return &postgresTestEngineWithDB{
+		engine: NewPostgresConsentEngine(db, "http://localhost:5173"),
+		db:     db,
+	}
+}
+
+// cleanupTestData removes all test data from the database
+func cleanupTestData(t *testing.T, db *sql.DB) {
+	_, err := db.Exec("DELETE FROM consent_records")
+	if err != nil {
+		t.Logf("Warning: failed to cleanup test data: %v", err)
+	}
+}
+
+// updateConsentExpiry directly updates the expires_at timestamp in the database
+// This is useful for tests to simulate expired consents without waiting
+func updateConsentExpiry(t *testing.T, db *sql.DB, consentID string, expiresAt time.Time) error {
+	_, err := db.Exec("UPDATE consent_records SET expires_at = $1 WHERE consent_id = $2", expiresAt, consentID)
+	if err != nil {
+		return fmt.Errorf("failed to update consent expiry: %w", err)
+	}
+	return nil
+}
+
+// TestWithPostgresEngine runs a test function with PostgreSQL engine
+func TestWithPostgresEngine(t *testing.T, testName string, testFunc func(t *testing.T, engine ConsentEngine)) {
+	// Only run PostgreSQL tests if explicitly enabled
+	if os.Getenv("TEST_USE_POSTGRES") == "true" {
+		t.Run("PostgreSQL_"+testName, func(t *testing.T) {
+			engine := setupPostgresTestEngine(t)
+			testFunc(t, engine)
+		})
+	} else {
+		// Skip test if PostgreSQL is not enabled
+		t.Skip("PostgreSQL tests not enabled (set TEST_USE_POSTGRES=true)")
+	}
+}


### PR DESCRIPTION
This PR may be bigger but most of it is moving files around, extracting service interface and implementation into service package `v1/services`; and also updating imports. All code uses `v1/models` package.

Any updates to handlers is to get the Build passing (update imports in test_utils.go and handler_test.go)


## Changelog
- extracted the ConsentEngine interface (engine.go)
- implemented `PostgresConsentEngine` (postgres.go) with all consent operations
- added database utilities (db.go) for connection management
- created utility functions (utils.go) for ID generation, duration parsing, and status transitions

## Test 
```bash
go mod tidy && go build . && go test ./... -count=1
```