### PR TITLE
Fix: Portal Backend validation workflow

### DIFF
--- a/.github/workflows/portal-backend-validate.yml
+++ b/.github/workflows/portal-backend-validate.yml
@@ -3,7 +3,7 @@ name: Validate Portal Backend
 on:
   pull_request:
     paths:
-      - '/portal-backend/**'
+      - 'portal-backend/**'
       - '.github/workflows/portal-backend-validate.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
The leading slash `/ ` in the GitHub workflow file for `portal-backend` validation, makes this an **absolute** path from the repository root, but GitHub Actions path filters don't work with leading slashes. This pattern will never match.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made
- Removed the leading slash `/` from the workflow

## Testing
- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts