### PR TITLE
Rename opendif mvp to core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ New to the project? Start with our [Development Guide](docs/contributing/develop
 
 If you have questions or want to discuss ideas:
 
--   Check our [Issues](https://github.com/OpenDIF/opendif-mvp/issues) to see if your question has been asked before
--   Open a new [Issue](https://github.com/OpenDIF/opendif-mvp/issues/new) for bugs or feature requests
--   Review open [Pull Requests](https://github.com/OpenDIF/opendif-mvp/pulls) to see what others are working on
+-   Check our [Issues](https://github.com/OpenDIF/opendif-core/issues) to see if your question has been asked before
+-   Open a new [Issue](https://github.com/OpenDIF/opendif-core/issues/new) for bugs or feature requests
+-   Review open [Pull Requests](https://github.com/OpenDIF/opendif-core/pulls) to see what others are working on
 
 ## Recognition
 

--- a/docs/LOCAL_CODE_QUALITY_SETUP.md
+++ b/docs/LOCAL_CODE_QUALITY_SETUP.md
@@ -39,8 +39,8 @@ All quality checks are orchestrated through a centralized Makefile that automati
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/OpenDIF/opendif-mvp.git
-cd opendif-mvp
+git clone https://github.com/OpenDIF/opendif-core.git
+cd opendif-core
 ```
 
 ### 2. Install Go Quality Tools

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -15,13 +15,13 @@ Before you begin, ensure you have the following installed:
 
 1.  **Fork and clone the repository:**
     ```bash
-    git clone https://github.com/YOUR_USERNAME/opendif-mvp.git
-    cd opendif-mvp
+    git clone https://github.com/YOUR_USERNAME/opendif-core.git
+    cd opendif-core
     ```
 
 2.  **Add the upstream remote:**
     ```bash
-    git remote add upstream https://github.com/OpenDIF/opendif-mvp.git
+    git remote add upstream https://github.com/OpenDIF/opendif-core.git
     ```
 
 3.  **Run the setup script:**
@@ -121,7 +121,7 @@ Before submitting a pull request, ensure:
 ## Project Structure
 
 ```
-opendif-mvp/
+opendif-core/
 ├── exchange/              # Go backend services
 │   ├── orchestration-engine/
 │   ├── policy-decision-point/
@@ -138,7 +138,7 @@ opendif-mvp/
 
 ## Getting Help
 
--   Check existing [Issues](https://github.com/OpenDIF/opendif-mvp/issues)
+-   Check existing [Issues](https://github.com/OpenDIF/opendif-core/issues)
 -   Review [Pull Request Guidelines](pull-requests.md)
 -   See [Reporting Issues](reporting-issues.md) for bug reports
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -4,7 +4,7 @@ We welcome pull requests from the community! This guide will help ensure your co
 
 ## Before You Start
 
-1.   **Check for existing work:** Search [open pull requests](https://github.com/OpenDIF/opendif-mvp/pulls) to avoid duplicate work
+1.   **Check for existing work:** Search [open pull requests](https://github.com/OpenDIF/opendif-core/pulls) to avoid duplicate work
 2.   **Discuss major changes:** For significant changes, consider opening an issue first to discuss the approach
 3.   **Read the documentation:** Review the [Development Guide](development.md) to set up your environment
 
@@ -102,4 +102,4 @@ Before submitting, ensure:
 -   Check [Reporting Issues](reporting-issues.md) for bug reporting
 -   See [Code of Conduct](../../CODE_OF_CONDUCT.md) for community standards
 
-[View Open Pull Requests](https://github.com/OpenDIF/opendif-mvp/pulls)
+[View Open Pull Requests](https://github.com/OpenDIF/opendif-core/pulls)

--- a/docs/contributing/reporting-issues.md
+++ b/docs/contributing/reporting-issues.md
@@ -4,7 +4,7 @@ We use GitHub Issues to track bugs, feature requests, and improvements. Your det
 
 ## Before Creating an Issue
 
-1.   **Search existing issues:** Check [open issues](https://github.com/OpenDIF/opendif-mvp/issues) and [closed issues](https://github.com/OpenDIF/opendif-mvp/issues?q=is%3Aissue+is%3Aclosed) to see if your issue has already been reported
+1.   **Search existing issues:** Check [open issues](https://github.com/OpenDIF/opendif-core/issues) and [closed issues](https://github.com/OpenDIF/opendif-core/issues?q=is%3Aissue+is%3Aclosed) to see if your issue has already been reported
 2.   **Check documentation:** Review the README and relevant documentation to see if your question is answered
 3.   **Verify it's a bug:** For behavior questions, ensure it's actually a bug and not expected behavior
 
@@ -130,6 +130,6 @@ We use labels to categorize issues:
 
 ## Security Issues
 
-**Do not** report security vulnerabilities through public GitHub issues. Instead, please contact the maintainers directly or use GitHub's [private vulnerability reporting](https://github.com/OpenDIF/opendif-mvp/security/advisories/new) feature.
+**Do not** report security vulnerabilities through public GitHub issues. Instead, please contact the maintainers directly or use GitHub's [private vulnerability reporting](https://github.com/OpenDIF/opendif-core/security/advisories/new) feature.
 
-[Open a new issue](https://github.com/OpenDIF/opendif-mvp/issues/new)
+[Open a new issue](https://github.com/OpenDIF/opendif-core/issues/new)

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
   external_labels:
-    cluster: 'opendif-mvp'
+    cluster: 'opendif-core'
     environment: 'local'
 
 scrape_configs:


### PR DESCRIPTION
rename opendif-mvp to opendif-core across the codebase. 

In Github Settings, already updated repo name to `opendif-core`