### PR TITLE
fix: correct repository URL case in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before deploying OpenDIF, you must configure an Identity Provider (IdP) to handl
 
 1.  **Clone the Repository**:
     ```bash
-    git clone https://github.com/open-dif/opendif-core.git
+    git clone https://github.com/OpenDIF/opendif-core.git
     cd opendif-core
     ```
 


### PR DESCRIPTION
## Summary

Corrects the casing of the repository URL in the README clone instructions from `open-dif/opendif-core` to `OpenDIF/opendif-core` so the clone command works as written.

## Type of Change

- [x] Documentation update

## Changes Made

- Fixed the repository URL case in `README.md` (`open-dif` → `OpenDIF`) in the "Clone the Repository" step.

## Testing

- [x] I have tested this change locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Additional Notes

Documentation-only change; no functional impact.
