### PR TITLE
chore: update shared module paths to OpenDIF repository structure

### DIFF
--- a/exchange/shared/config/go.mod
+++ b/exchange/shared/config/go.mod
@@ -1,3 +1,3 @@
-module github.com/gov-dx-sandbox/exchange/shared/config
+module github.com/OpenDIF/opendif-core/exchange/shared/config
 
 go 1.21

--- a/exchange/shared/constants/go.mod
+++ b/exchange/shared/constants/go.mod
@@ -1,3 +1,3 @@
-module github.com/gov-dx-sandbox/exchange/shared/constants
+module github.com/OpenDIF/opendif-core/exchange/shared/constants
 
 go 1.24.6

--- a/exchange/shared/monitoring/go.mod
+++ b/exchange/shared/monitoring/go.mod
@@ -1,4 +1,4 @@
-module github.com/gov-dx-sandbox/exchange/shared/monitoring
+module github.com/OpenDIF/opendif-core/exchange/shared/monitoring
 
 go 1.24.6
 

--- a/exchange/shared/utils/go.mod
+++ b/exchange/shared/utils/go.mod
@@ -1,3 +1,3 @@
-module github.com/gov-dx-sandbox/exchange/shared/utils
+module github.com/OpenDIF/opendif-core/exchange/shared/utils
 
 go 1.24.6


### PR DESCRIPTION
## Summary

Updates the `module` path in the four `exchange/shared/*` Go modules from the legacy `github.com/gov-dx-sandbox/exchange/shared/*` to `github.com/OpenDIF/opendif-core/exchange/shared/*`, aligning the module names with the current OpenDIF repository structure.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Renamed the `module` declaration in:
  - `exchange/shared/config/go.mod`
  - `exchange/shared/constants/go.mod`
  - `exchange/shared/monitoring/go.mod`
  - `exchange/shared/utils/go.mod`
- No source, `require`, or `replace` changes — consumers continue to resolve these via local `replace` directives.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

Verified `go build -a ./...` and `go vet ./...` pass (exit 0) for all three consumers (`policy-decision-point`, `consent-engine`, `orchestration-engine`). Local `replace` directives resolve these modules by directory, so Go does not enforce the target's declared module path — the rename does not affect local builds.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Additional Notes

Consumers (`policy-decision-point`, `consent-engine`, `orchestration-engine`) still `require`/`replace`/`import` the old `gov-dx-sandbox/...` paths, so this rename is currently cosmetic — nothing references the new module names yet. A follow-up is needed to actually migrate consumers to the new path. Note also that the new path (`OpenDIF/opendif-core`) does not match the real remote (`github.com/opendif/opendif-mvp`), so this does not by itself make the modules `go get`-able.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
