### PR TITLE
refactor(consent-engine): consume shared modules as published deps + service-folder Docker context

### DIFF
--- a/.github/workflows/consent-engine-publish.yml
+++ b/.github/workflows/consent-engine-publish.yml
@@ -58,7 +58,7 @@ jobs:
         id: build-push
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/consent-engine-validate.yml
+++ b/.github/workflows/consent-engine-validate.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: false
           load: true

--- a/exchange/consent-engine/.dockerignore
+++ b/exchange/consent-engine/.dockerignore
@@ -1,0 +1,26 @@
+# Only Go source + go.mod/go.sum are needed to build the binary.
+# Keep the build context small and cache-stable by excluding everything else.
+
+# Test & coverage artifacts
+coverage.out
+coverage.html
+*.test
+
+# Docs & API spec (not embedded; not copied into the final image)
+README.md
+openapi.yaml
+
+# Local environment / secrets
+.env
+.env.*
+*.env
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Editor / OS cruft
+.DS_Store
+.idea/
+.vscode/
+*.swp

--- a/exchange/consent-engine/Dockerfile
+++ b/exchange/consent-engine/Dockerfile
@@ -12,19 +12,14 @@ ARG GIT_COMMIT
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
 
-# Copy all shared dependencies
-COPY exchange/consent-engine/go.mod exchange/consent-engine/go.sum ./exchange/consent-engine/
-COPY exchange/shared/monitoring/ ./exchange/shared/monitoring/
-COPY exchange/shared/utils/ ./exchange/shared/utils/
-
-# Copy go mod files and source code
-COPY exchange/consent-engine/ ./exchange/consent-engine/
-
-WORKDIR /app/exchange/consent-engine/
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+# Shared modules (github.com/OpenDIF/opendif-core/...) are now published and
+# fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 
-# Copy source code
-COPY exchange/consent-engine/ .
+# Copy source code (this layer is invalidated only on code changes)
+COPY . .
 
 # Build the application with build info from consent-engine directory
 RUN CGO_ENABLED=0 GOOS=linux go build \

--- a/exchange/consent-engine/go.mod
+++ b/exchange/consent-engine/go.mod
@@ -3,14 +3,11 @@ module github.com/gov-dx-sandbox/exchange/consent-engine
 go 1.24.6
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/OpenDIF/opendif-core/exchange/shared/monitoring v0.0.0-20260702074442-13c5fdc4f37d
+	github.com/OpenDIF/opendif-core/exchange/shared/utils v0.0.0-20260702074442-13c5fdc4f37d
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
-	github.com/gov-dx-sandbox/exchange/shared/utils v0.0.0
-)
-
-require (
-	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/gov-dx-sandbox/exchange/shared/monitoring v0.0.0
 	github.com/stretchr/testify v1.11.1
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -57,7 +54,3 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/gov-dx-sandbox/exchange/shared/monitoring => ../shared/monitoring
-
-replace github.com/gov-dx-sandbox/exchange/shared/utils => ../shared/utils

--- a/exchange/consent-engine/go.sum
+++ b/exchange/consent-engine/go.sum
@@ -1,5 +1,9 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/OpenDIF/opendif-core/exchange/shared/monitoring v0.0.0-20260702074442-13c5fdc4f37d h1:fqnz0YT3S/n9PVx3v72Fr7ViqkUHgBJT+YejP2KQIe8=
+github.com/OpenDIF/opendif-core/exchange/shared/monitoring v0.0.0-20260702074442-13c5fdc4f37d/go.mod h1:UV8Cf12gqfbmwsY2eZYB/NsaLx6tnX48gQXMuXZlA/E=
+github.com/OpenDIF/opendif-core/exchange/shared/utils v0.0.0-20260702074442-13c5fdc4f37d h1:SywbXt5j79fCx/x73HeYOxUZvDepAwVakOgunMAlARE=
+github.com/OpenDIF/opendif-core/exchange/shared/utils v0.0.0-20260702074442-13c5fdc4f37d/go.mod h1:UX3ZaMqgpqDKfLQ3fNUS+eR6X/gFzXpJXoUYKQuyObs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/exchange/consent-engine/internal/config/config.go
+++ b/exchange/consent-engine/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"time"
 
-	"github.com/gov-dx-sandbox/exchange/shared/utils"
+	"github.com/OpenDIF/opendif-core/exchange/shared/utils"
 )
 
 // Config holds all configuration for a service

--- a/exchange/consent-engine/main.go
+++ b/exchange/consent-engine/main.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/OpenDIF/opendif-core/exchange/shared/monitoring"
+	"github.com/OpenDIF/opendif-core/exchange/shared/utils"
 	"github.com/gov-dx-sandbox/exchange/consent-engine/internal/config"
-	"github.com/gov-dx-sandbox/exchange/shared/monitoring"
-	"github.com/gov-dx-sandbox/exchange/shared/utils"
 
 	// V1 API imports
 	v1auth "github.com/gov-dx-sandbox/exchange/consent-engine/v1/auth"

--- a/exchange/consent-engine/v1/router/router.go
+++ b/exchange/consent-engine/v1/router/router.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gov-dx-sandbox/exchange/consent-engine/v1/handlers"
 	"github.com/gov-dx-sandbox/exchange/consent-engine/v1/middleware"
 
-	sharedUtils "github.com/gov-dx-sandbox/exchange/shared/utils"
+	sharedUtils "github.com/OpenDIF/opendif-core/exchange/shared/utils"
 )
 
 // V1Router handles all V1 API route registration

--- a/exchange/docker-compose.yml
+++ b/exchange/docker-compose.yml
@@ -39,8 +39,8 @@ services:
 
   consent-engine:
     build:
-      context: .
-      dockerfile: consent-engine/Dockerfile
+      context: ./consent-engine
+      dockerfile: Dockerfile
       args:
         SERVICE_PATH: consent-engine
         BUILD_VERSION: ${BUILD_VERSION:-dev}

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -37,8 +37,8 @@ services:
   # Consent Engine Service
   consent-engine:
     build:
-      context: ../..
-      dockerfile: exchange/consent-engine/Dockerfile
+      context: ../../exchange/consent-engine
+      dockerfile: Dockerfile
     environment:
       PORT: 8081
       LOG_LEVEL: info


### PR DESCRIPTION
## Summary

Migrates the Consent Engine (CE) to consume its shared packages (`monitoring`, `utils`) as **published Go modules** (`github.com/OpenDIF/opendif-core/exchange/shared/*`) instead of local `replace` directives, and updates the CE Docker build to use the **service directory as its build context**. This mirrors the change already merged for the Policy Decision Point (#434).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **`go.mod`**: dropped the local `replace` directives for `shared/monitoring` and `shared/utils`; both are now versioned requires on `github.com/OpenDIF/opendif-core/...`. Ran `go mod tidy` (reclassified them as direct dependencies).
- **`.go` imports** (`main.go`, `internal/config/config.go`, `v1/router/router.go`): use the new module path.
- **`Dockerfile`**: build context is now the service directory. Copies `go.mod`/`go.sum` and runs `go mod download` (shared modules fetched from the module proxy); removed both `COPY exchange/shared/...` steps, the redundant duplicate source-copy, and the repo-root path prefixes.
- **`.dockerignore`**: added for the service directory (excludes coverage/test artifacts, docs, env files, editor cruft).
- **Build contexts updated to match** the new Dockerfile:
  - `exchange/docker-compose.yml` → `context: ./consent-engine`
  - `tests/integration/docker-compose.test.yml` → `context: ../../exchange/consent-engine`
  - `.github/workflows/consent-engine-{publish,validate}.yml` → `context: ${{ env.SERVICE_PATH }}`

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

- `go build ./...`, `go vet ./...`, and `go mod tidy` are clean for consent-engine.
- `docker build` on `exchange/consent-engine` succeeds (exit 0); the shared modules resolve from the public module proxy — no credentials needed in the build.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #434 (same migration for the Policy Decision Point).

## Additional Notes

- `orchestration-engine` is now the only remaining service using the repo-root build context + local `replace`. It additionally depends on a root-level `shared/audit` module, so migrating it requires that module to be published as well — left as a follow-up.
- The `file:` inputs in the workflows remain `${{ env.SERVICE_PATH }}/Dockerfile` — in `docker/build-push-action`, `file` is resolved relative to the workspace, not to `context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
