### PR TITLE
refactor: update module path for shared audit to OpenDIF core

### DIFF
--- a/shared/audit/go.mod
+++ b/shared/audit/go.mod
@@ -1,3 +1,3 @@
-module github.com/gov-dx-sandbox/shared/audit
+module github.com/OpenDIF/opendif-core/shared/audit
 
 go 1.24.6


### PR DESCRIPTION
## Summary

Updates the module path of the `shared/audit` module from the legacy `github.com/gov-dx-sandbox/shared/audit` to `github.com/OpenDIF/opendif-core/shared/audit`, aligning it with the new OpenDIF core repository URL. This completes the module-path migration for the shared audit package so downstream services resolve it under the correct import path.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Updated the module declaration in `shared/audit/go.mod` from `github.com/gov-dx-sandbox/shared/audit` to `github.com/OpenDIF/opendif-core/shared/audit`.

## Testing

- [ ] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Additional Notes

Module-path-only change (single line in `go.mod`); no functional code was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
