### PR TITLE
fix(consent-engine): align env template with config (add HOST/RUN_MIGRATION, drop dead TEST_DB vars)

### DIFF
--- a/exchange/consent-engine/.env.template
+++ b/exchange/consent-engine/.env.template
@@ -4,6 +4,7 @@
 # Service Configuration
 # =============================================================================
 PORT=8081
+HOST=0.0.0.0
 ENVIRONMENT=local
 CONSENT_PORTAL_URL=
 # Add Comma Separated, (CONSENT_PORTAL_URL will be auto added)
@@ -20,20 +21,14 @@ DB_NAME=consent_engine
 DB_SSLMODE=require
 
 # =============================================================================
+# Migration Configuration
+# =============================================================================
+RUN_MIGRATION=false
+
+# =============================================================================
 # IDP Configuration
 # =============================================================================
 IDP_ORG_NAME=YOUR_ORG_NAME
 IDP_ISSUER=
 IDP_AUDIENCE=YOUR_AUDIENCE
 IDP_JWKS_URL=
-
-# =============================================================================
-# Test Database Configuration (for running tests)
-# =============================================================================
-TEST_DB_HOST=localhost
-TEST_DB_PORT=5432
-TEST_DB_USERNAME=postgres
-TEST_DB_PASSWORD=password
-TEST_DB_DATABASE=consent_engine_test
-TEST_DB_SSLMODE=disable
-TEST_USE_POSTGRES=true


### PR DESCRIPTION
## Summary

Brings the Consent Engine `.env.template` in line with the variables the code actually reads (`internal/config/config.go` + `v1/database/database.go`). Documentation/config only — no code or behavioral change.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **Added `HOST`** — read by `internal/config/config.go` (`GetEnvOrDefault("HOST", "0.0.0.0")`) but was missing from the template.
- **Added `RUN_MIGRATION`** (new Migration Configuration section) — read by `v1/database/database.go` to gate GORM `AutoMigrate`, but was missing from the template.
- **Removed the dead `TEST_DB_*` / `TEST_USE_POSTGRES` block** — these 7 variables are not referenced by any Go code, script, Makefile, or CI.
- Kept all matching variables (`PORT`, `ENVIRONMENT`, `CONSENT_PORTAL_URL`, `CORS_ALLOWED_ORIGINS`, `DB_*`, `IDP_*`). `IDP_ORG_NAME` is retained because the CE code still uses it.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

- Verified against `internal/config/config.go` and `v1/database/database.go` that the template variables are exactly the set the code reads. No code changed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Related to #440 (equivalent env-template cleanup for the Policy Decision Point).

## Additional Notes

- Unlike PDP (#440), the CE code still uses `IDP_ORG_NAME`, so it is intentionally kept here. Applying the same OIDC cleanup to CE would be a separate code change.
- `LOG_LEVEL`/`LOG_FORMAT` are intentionally absent — they are flag defaults derived from `ENVIRONMENT`, not environment variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
