### PR TITLE
chore(orchestration-engine): clean up Dockerfile and make DB config generic

### DIFF
--- a/exchange/orchestration-engine/Dockerfile
+++ b/exchange/orchestration-engine/Dockerfile
@@ -34,10 +34,6 @@ WORKDIR /app
 # Copy binary from builder
 COPY --from=builder /app/orchestration-engine .
 
-
-# Install wget for health checks
-RUN apk --no-cache add wget
-
 # Create config directory
 RUN mkdir -p /app/config && \
     chown -R appuser:appuser /app
@@ -45,26 +41,8 @@ RUN mkdir -p /app/config && \
 # Switch to non-root user
 USER appuser
 
-# Environment variables with defaults
-ENV SERVER_PORT=4000
-ENV SERVER_HOST=0.0.0.0
-ENV LOG_LEVEL=info
-ENV CONFIG_FILE=/app/config.json
-
-# Database Configuration (PostgreSQL example)
-ENV DB_HOST=localhost
-ENV DB_PORT=5432
-ENV DB_USER=user
-ENV DB_PASSWORD=password
-ENV DB_NAME=orchestration_db
-ENV DB_SSLMODE=disable
-
 # Expose port
 EXPOSE 4000
-
-# Health check (adjust endpoint as needed)
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:${SERVER_PORT}/health || exit 1
 
 # Run the server
 CMD ["./orchestration-engine"]

--- a/exchange/orchestration-engine/server/server.go
+++ b/exchange/orchestration-engine/server/server.go
@@ -210,34 +210,16 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 // getDatabaseConnectionString returns the database connection string from environment variables
 func getDatabaseConnectionString() string {
-	// Check for Choreo environment variables first
-	choreoHost := os.Getenv("CHOREO_DB_OE_HOSTNAME")
-	choreoUser := os.Getenv("CHOREO_DB_OE_USERNAME")
-	choreoPassword := os.Getenv("CHOREO_DB_OE_PASSWORD")
-	choreoDB := os.Getenv("CHOREO_DB_OE_DATABASENAME")
+	host := getEnv("DB_HOST", "localhost")
+	port := getEnv("DB_PORT", "5432")
+	user := getEnv("DB_USER", "postgres")
+	password := getEnv("DB_PASSWORD", "")
+	dbname := getEnv("DB_NAME", "orchestration_engine")
+	sslmode := getEnv("DB_SSLMODE", "disable")
 
-	// Use Choreo variables if available, otherwise fall back to standard environment variables
-	var host, port, user, password, dbname, sslmode string
-
-	if choreoHost != "" {
-		host = choreoHost
-		port = getEnv("CHOREO_DB_OE_PORT", "5432")
-		user = choreoUser
-		password = choreoPassword
-		dbname = choreoDB
-		sslmode = "require" // Choreo typically requires SSL
-	} else {
-		host = getEnv("DB_HOST", "localhost")
-		port = getEnv("DB_PORT", "5432")
-		user = getEnv("DB_USER", "postgres")
-		password = getEnv("DB_PASSWORD", "")
-		dbname = getEnv("DB_NAME", "orchestration_engine")
-		sslmode = getEnv("DB_SSLMODE", "disable")
-
-		// Require password from environment - no default
-		if password == "" {
-			logger.Log.Warn("DB_PASSWORD not set - database connection may fail")
-		}
+	// Require password from environment - no default
+	if password == "" {
+		logger.Log.Warn("DB_PASSWORD not set - database connection may fail")
 	}
 
 	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",

--- a/exchange/orchestration-engine/server/server_test.go
+++ b/exchange/orchestration-engine/server/server_test.go
@@ -118,25 +118,6 @@ func TestGetEnv(t *testing.T) {
 }
 
 func TestGetDatabaseConnectionString(t *testing.T) {
-	t.Run("Choreo environment variables set", func(t *testing.T) {
-		os.Setenv("CHOREO_DB_OE_HOSTNAME", "choreo-host")
-		os.Setenv("CHOREO_DB_OE_PORT", "5433")
-		os.Setenv("CHOREO_DB_OE_USERNAME", "choreo-user")
-		os.Setenv("CHOREO_DB_OE_PASSWORD", "choreo-password")
-		os.Setenv("CHOREO_DB_OE_DATABASENAME", "choreo-db")
-		defer func() {
-			os.Unsetenv("CHOREO_DB_OE_HOSTNAME")
-			os.Unsetenv("CHOREO_DB_OE_PORT")
-			os.Unsetenv("CHOREO_DB_OE_USERNAME")
-			os.Unsetenv("CHOREO_DB_OE_PASSWORD")
-			os.Unsetenv("CHOREO_DB_OE_DATABASENAME")
-		}()
-
-		connStr := getDatabaseConnectionString()
-		expected := "host=choreo-host port=5433 user=choreo-user password=choreo-password dbname=choreo-db sslmode=require"
-		assert.Equal(t, expected, connStr)
-	})
-
 	t.Run("Standard environment variables set", func(t *testing.T) {
 		os.Setenv("DB_HOST", "standard-host")
 		os.Setenv("DB_PORT", "5434")
@@ -179,11 +160,6 @@ func TestGetDatabaseConnectionString(t *testing.T) {
 	})
 
 	t.Run("No environment variables set (defaults)", func(t *testing.T) {
-		os.Unsetenv("CHOREO_DB_OE_HOSTNAME")
-		os.Unsetenv("CHOREO_DB_OE_PORT")
-		os.Unsetenv("CHOREO_DB_OE_USERNAME")
-		os.Unsetenv("CHOREO_DB_OE_PASSWORD")
-		os.Unsetenv("CHOREO_DB_OE_DATABASENAME")
 		os.Unsetenv("DB_HOST")
 		os.Unsetenv("DB_PORT")
 		os.Unsetenv("DB_USER")


### PR DESCRIPTION
## Summary

Cleans up the orchestration-engine Dockerfile and database configuration, removing dead/Choreo-specific code now that the service is no longer deployed on Choreo.

### Dockerfile
- Removed unused `ENV`s: `SERVER_PORT`, `SERVER_HOST`, `LOG_LEVEL`, `CONFIG_FILE` (none referenced by the app — the server reads `PORT`, not `SERVER_PORT`).
- Removed hardcoded `DB_*` `ENV`s, including the baked-in `DB_PASSWORD` (a credential in image layers) whose defaults also disagreed with the code's own defaults. These are injected at runtime instead.
- Removed the `HEALTHCHECK` and its orphaned `RUN apk add wget` — the orchestrator does its own liveness/readiness probing against the `/health` endpoint, so the Docker healthcheck was redundant.

### Database config (`server.go`)
- Removed the Choreo branch (`CHOREO_DB_OE_*` env vars + forced `sslmode=require`) from `getDatabaseConnectionString()`.
- Now reads the standard `DB_*` vars with sensible defaults, keeping the missing-password warning. Generic and portable.

### Tests
- Removed the Choreo test case and stray Choreo `Unsetenv` calls.

## Test plan
- `go build ./...` passes
- `go test ./server/` passes