### PR TITLE
chore(exchange): clean up CE/PDP Dockerfiles and compose healthchecks

### DIFF
--- a/exchange/consent-engine/Dockerfile
+++ b/exchange/consent-engine/Dockerfile
@@ -4,7 +4,6 @@ FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 # Build arguments
-ARG SERVICE_PATH=consent-engine
 ARG BUILD_VERSION=latest
 ARG BUILD_TIME
 ARG GIT_COMMIT
@@ -24,13 +23,13 @@ COPY . .
 # Build the application with build info from consent-engine directory
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-w -s -X main.Version=${BUILD_VERSION} -X main.BuildTime=${BUILD_TIME} -X main.GitCommit=${GIT_COMMIT}" \
-    -o /app/service_binary .
+    -o /app/ce .
 
 # Final stage
 FROM alpine:3.17
 
 # Install runtime dependencies
-RUN apk --no-cache add ca-certificates tzdata wget
+RUN apk --no-cache add ca-certificates tzdata
 
 # Create non-root user with specific UID for WSO2 Choreo compliance
 RUN adduser -D -s /bin/sh -u 10001 appuser
@@ -39,7 +38,7 @@ RUN adduser -D -s /bin/sh -u 10001 appuser
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/service_binary /app/
+COPY --from=builder /app/ce /app/
 
 # Change ownership to appuser
 RUN chown -R appuser:appuser /app
@@ -51,12 +50,7 @@ USER 10001
 EXPOSE 8081
 
 # Set environment variables
-ENV CONFIG_DIR=/app/config
 ENV ENVIRONMENT=production
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8081/health || exit 1
-
-# Run the application with environment-based flags
-CMD ["./service_binary", "-env=${ENVIRONMENT:-production}", "-port=8081"]
+# Run the application (env and port are read from the ENVIRONMENT and PORT variables)
+CMD ["./ce"]

--- a/exchange/docker-compose.yml
+++ b/exchange/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       context: ./policy-decision-point
       dockerfile: Dockerfile
       args:
-        SERVICE_PATH: policy-decision-point
         BUILD_VERSION: ${BUILD_VERSION:-dev}
         BUILD_TIME: ${BUILD_TIME:-2025-09-09T16:30:00Z}
         GIT_COMMIT: ${GIT_COMMIT:-local}
@@ -27,12 +26,6 @@ services:
       - LOG_FORMAT=${LOG_FORMAT:-text}
       - SERVICE_NAME=policy-decision-point
       - OTEL_METRICS_EXPORTER=${OTEL_METRICS_EXPORTER:-prometheus}
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8082/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
     restart: unless-stopped
     networks:
       - opendif-network
@@ -42,7 +35,6 @@ services:
       context: ./consent-engine
       dockerfile: Dockerfile
       args:
-        SERVICE_PATH: consent-engine
         BUILD_VERSION: ${BUILD_VERSION:-dev}
         BUILD_TIME: ${BUILD_TIME:-2025-09-09T16:30:00Z}
         GIT_COMMIT: ${GIT_COMMIT:-local}
@@ -54,12 +46,6 @@ services:
       - PORT=8081
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - LOG_FORMAT=${LOG_FORMAT:-text}
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8081/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
     restart: unless-stopped
     networks:
       - opendif-network
@@ -69,7 +55,6 @@ services:
       context: ./orchestration-engine
       dockerfile: Dockerfile
       args:
-        SERVICE_PATH: orchestration-engine
         BUILD_VERSION: ${BUILD_VERSION:-dev}
         BUILD_TIME: ${BUILD_TIME:-2025-09-09T16:30:00Z}
         GIT_COMMIT: ${GIT_COMMIT:-local}
@@ -86,7 +71,7 @@ services:
       - AUDIT_SERVICE_URL=${AUDIT_SERVICE_URL:-http://audit-service:3001}
       - ENABLE_AUDIT=${ENABLE_AUDIT:-true}
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4000/health"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:4000/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/exchange/policy-decision-point/Dockerfile
+++ b/exchange/policy-decision-point/Dockerfile
@@ -4,7 +4,6 @@ FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 # Build arguments
-ARG SERVICE_PATH=policy-decision-point
 ARG BUILD_VERSION=latest
 ARG BUILD_TIME
 ARG GIT_COMMIT
@@ -24,13 +23,13 @@ COPY . .
 # Build the application with build info
 RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags="-w -s -X main.Version=${BUILD_VERSION} -X main.BuildTime=${BUILD_TIME} -X main.GitCommit=${GIT_COMMIT}" \
-    -o /app/service_binary .
+    -o /app/pdp .
 
 # Final stage
 FROM alpine:3.17
 
 # Install runtime dependencies
-RUN apk --no-cache add ca-certificates tzdata wget
+RUN apk --no-cache add ca-certificates tzdata
 
 # Create non-root user with specific UID for WSO2 Choreo compliance
 RUN adduser -D -s /bin/sh -u 10001 appuser
@@ -39,7 +38,7 @@ RUN adduser -D -s /bin/sh -u 10001 appuser
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/service_binary /app/
+COPY --from=builder /app/pdp /app/
 
 # Change ownership to appuser
 RUN chown -R appuser:appuser /app
@@ -51,12 +50,7 @@ USER 10001
 EXPOSE 8082
 
 # Set environment variables
-ENV CONFIG_DIR=/app/config
 ENV ENVIRONMENT=production
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:8082/health || exit 1
-
-# Run the application with environment-based flags
-CMD ["./service_binary", "-env=${ENVIRONMENT:-production}", "-port=8082"]
+# Run the application (env and port are read from the ENVIRONMENT and PORT variables)
+CMD ["./pdp"]


### PR DESCRIPTION
## Summary

Applies the same cleanup done for orchestration-engine (#442) to consent-engine and policy-decision-point, plus tidies `docker-compose.yml`.

### CE & PDP Dockerfiles
- Removed the `HEALTHCHECK` and dropped `wget` from runtime deps (it existed only for the healthcheck; the orchestrator probes `/health` directly).
- Removed dead `ENV CONFIG_DIR=/app/config` — not referenced anywhere in the Go code. Kept `ENV ENVIRONMENT=production`, which the app reads via `GetEnvOrDefault("ENVIRONMENT", "local")`.
- Fixed the exec-form `CMD`: dropped `-env=${ENVIRONMENT:-production}`, which was never shell-expanded (exec form runs no shell) so the binary received the literal string. Env now comes from the `ENVIRONMENT` variable.
- Removed the unused `SERVICE_PATH` build arg (declared but never referenced).

### docker-compose.yml
- Removed the now-unused `SERVICE_PATH` build args from all three services.
- Removed the `healthcheck` blocks from consent-engine and policy-decision-point — only orchestration-engine keeps one.
- Converted the orchestration-engine healthcheck from `--spider` (HEAD) to a GET (`wget -q -O /dev/null`), using BusyBox-wget-compatible flags since the OE image no longer bundles GNU wget.

## Test plan
- `docker compose config -q` validates
- Pre-commit hooks (build, vet, tests for affected services) pass