### PR TITLE
refactor: consume shared audit as published dep in portal-backend

### DIFF
--- a/portal-backend/go.mod
+++ b/portal-backend/go.mod
@@ -4,10 +4,9 @@ go 1.24.6
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/OpenDIF/opendif-core/shared/audit v0.0.0-20260702135451-a897215dde39
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
-	github.com/gov-dx-sandbox/portal-backend/shared/utils v0.0.0
-	github.com/gov-dx-sandbox/shared/audit v0.0.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektah/gqlparser/v2 v2.5.30
@@ -20,28 +19,19 @@ require (
 require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/gov-dx-sandbox/portal-backend/models => ./models
-
-replace github.com/gov-dx-sandbox/portal-backend/shared/utils => ./shared/utils
-
-replace github.com/gov-dx-sandbox/shared/audit => ../shared/audit

--- a/portal-backend/go.sum
+++ b/portal-backend/go.sum
@@ -1,5 +1,7 @@
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/OpenDIF/opendif-core/shared/audit v0.0.0-20260702135451-a897215dde39 h1:nsZHnO7ZDncC7ByPGyS7Pm4BX67bE0MsEwhkz+RAoGc=
+github.com/OpenDIF/opendif-core/shared/audit v0.0.0-20260702135451-a897215dde39/go.mod h1:O3gRvxopCQa/b/IBPINRG+LjKWqFVz2g80e5Kz0YQXI=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/portal-backend/main.go
+++ b/portal-backend/main.go
@@ -10,12 +10,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/OpenDIF/opendif-core/shared/audit"
 	"github.com/gov-dx-sandbox/portal-backend/shared/utils"
 	v1 "github.com/gov-dx-sandbox/portal-backend/v1"
 	v1handlers "github.com/gov-dx-sandbox/portal-backend/v1/handlers"
 	v1middleware "github.com/gov-dx-sandbox/portal-backend/v1/middleware"
 	v1models "github.com/gov-dx-sandbox/portal-backend/v1/models"
-	auditclient "github.com/gov-dx-sandbox/shared/audit"
 	"github.com/joho/godotenv"
 )
 
@@ -115,8 +115,8 @@ func main() {
 	// Services will work without auditing - gracefully degrades if disabled via ENABLE_AUDIT=false
 	// or if CHOREO_AUDIT_CONNECTION_SERVICEURL is not provided
 	auditServiceURL := utils.GetEnvOrDefault("CHOREO_AUDIT_CONNECTION_SERVICEURL", "http://localhost:3001")
-	auditClient := auditclient.NewClient(auditServiceURL)
-	auditclient.InitializeGlobalAudit(auditClient)
+	auditClient := audit.NewClient(auditServiceURL)
+	audit.InitializeGlobalAudit(auditClient)
 
 	// Apply middleware chain (CORS -> JWT Auth -> Authorization) to the API mux ONLY
 	protectedAPIHandler := corsMiddleware(

--- a/portal-backend/shared/utils/go.mod
+++ b/portal-backend/shared/utils/go.mod
@@ -1,3 +1,0 @@
-module github.com/gov-dx-sandbox/portal-backend/shared/utils
-
-go 1.24.6

--- a/portal-backend/v1/middleware/audit_middleware.go
+++ b/portal-backend/v1/middleware/audit_middleware.go
@@ -5,13 +5,13 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/OpenDIF/opendif-core/shared/audit"
 	"github.com/gov-dx-sandbox/portal-backend/v1/models"
-	auditpkg "github.com/gov-dx-sandbox/shared/audit"
 )
 
 // LogAudit logs an audit event for portal-backend operations by extracting request info and creating an audit log
-func LogAudit(client auditpkg.AuditClient, r *http.Request, resource string, resourceID *string, status string) {
-	// Skip if audit client is not enabled
+func LogAudit(client audit.Auditor, r *http.Request, resource string, resourceID *string, status string) {
+	// Skip if audit client is not set or not enabled
 	if client == nil || !client.IsEnabled() {
 		return
 	}
@@ -45,13 +45,13 @@ func LogAudit(client auditpkg.AuditClient, r *http.Request, resource string, res
 
 	// Create audit event using shared/audit DTO
 	// Use shared utilities for timestamp and metadata marshaling
-	timestamp := auditpkg.CurrentTimestamp()
-	additionalMetadata := auditpkg.MarshalMetadata(map[string]interface{}{
+	timestamp := audit.CurrentTimestamp()
+	additionalMetadata := audit.MarshalMetadata(map[string]interface{}{
 		"resource":   resource,
 		"resourceId": resourceID,
 	})
 
-	auditRequest := &auditpkg.AuditLogRequest{
+	auditRequest := &audit.AuditLogRequest{
 		TraceID:            nil, // No trace ID for standalone management events
 		Timestamp:          timestamp,
 		EventType:          eventType,
@@ -122,7 +122,7 @@ func extractActorInfoFromRequest(r *http.Request) (actorType string, actorID *st
 
 // LogAuditEvent - global function for easy access from handlers
 func LogAuditEvent(r *http.Request, resource string, resourceID *string, status string) {
-	globalMiddleware := auditpkg.GetGlobalAuditMiddleware()
+	globalMiddleware := audit.GetGlobalAuditMiddleware()
 	if globalMiddleware != nil {
 		LogAudit(globalMiddleware.Client(), r, resource, resourceID, status)
 	} else {

--- a/portal-backend/v1/middleware/audit_middleware_test.go
+++ b/portal-backend/v1/middleware/audit_middleware_test.go
@@ -9,15 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OpenDIF/opendif-core/shared/audit"
 	"github.com/gov-dx-sandbox/portal-backend/v1/models"
 	"github.com/gov-dx-sandbox/portal-backend/v1/utils"
-	auditpkg "github.com/gov-dx-sandbox/shared/audit"
 )
 
-// mockAuditClient implements auditpkg.AuditClient interface for testing
+// mockAuditClient implements audit.AuditClient interface for testing
 type mockAuditClient struct {
 	enabled         bool
-	receivedEvents  []*auditpkg.AuditLogRequest
+	receivedEvents  []*audit.AuditLogRequest
 	mu              sync.Mutex
 	requestReceived chan bool
 }
@@ -25,12 +25,12 @@ type mockAuditClient struct {
 func newMockAuditClient(enabled bool) *mockAuditClient {
 	return &mockAuditClient{
 		enabled:         enabled,
-		receivedEvents:  make([]*auditpkg.AuditLogRequest, 0),
+		receivedEvents:  make([]*audit.AuditLogRequest, 0),
 		requestReceived: make(chan bool, 1),
 	}
 }
 
-func (m *mockAuditClient) LogEvent(ctx context.Context, event *auditpkg.AuditLogRequest) {
+func (m *mockAuditClient) LogEvent(ctx context.Context, event *audit.AuditLogRequest) {
 	m.mu.Lock()
 	m.receivedEvents = append(m.receivedEvents, event)
 	m.mu.Unlock()
@@ -46,12 +46,12 @@ func (m *mockAuditClient) IsEnabled() bool {
 
 func TestAuditMiddleware_Initialization(t *testing.T) {
 	// Reset global state for this test
-	auditpkg.ResetGlobalAuditMiddleware()
+	audit.ResetGlobalAuditMiddleware()
 
 	// Test with audit enabled
 	mockClient1 := newMockAuditClient(true)
-	auditpkg.InitializeGlobalAudit(mockClient1)
-	auditMiddleware := auditpkg.GetGlobalAuditMiddleware()
+	audit.InitializeGlobalAudit(mockClient1)
+	auditMiddleware := audit.GetGlobalAuditMiddleware()
 	if auditMiddleware.Client() == nil {
 		t.Error("Expected audit middleware to have client when provided")
 	}
@@ -60,10 +60,10 @@ func TestAuditMiddleware_Initialization(t *testing.T) {
 	}
 
 	// Test with audit disabled (create new instance, but global should already be set)
-	auditpkg.ResetGlobalAuditMiddleware()
+	audit.ResetGlobalAuditMiddleware()
 	mockClient2 := newMockAuditClient(false)
-	auditpkg.InitializeGlobalAudit(mockClient2)
-	auditMiddleware2 := auditpkg.GetGlobalAuditMiddleware()
+	audit.InitializeGlobalAudit(mockClient2)
+	auditMiddleware2 := audit.GetGlobalAuditMiddleware()
 	if auditMiddleware2.Client() == nil {
 		t.Error("Expected audit middleware to have client instance even when disabled")
 	}
@@ -74,11 +74,11 @@ func TestAuditMiddleware_Initialization(t *testing.T) {
 
 func TestLogAuditEvent_GlobalFunction(t *testing.T) {
 	// Reset global state for this test
-	auditpkg.ResetGlobalAuditMiddleware()
+	audit.ResetGlobalAuditMiddleware()
 
 	// Initialize global audit middleware
 	mockClient := newMockAuditClient(true)
-	auditpkg.InitializeGlobalAudit(mockClient)
+	audit.InitializeGlobalAudit(mockClient)
 
 	// Test that LogAuditEvent doesn't panic when called
 	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
@@ -117,7 +117,7 @@ func TestLogAudit_ProcessesWriteOperations(t *testing.T) {
 
 func TestAuditMiddleware_ThreadSafety(t *testing.T) {
 	// Reset global state for this test
-	auditpkg.ResetGlobalAuditMiddleware()
+	audit.ResetGlobalAuditMiddleware()
 
 	const numGoroutines = 10
 	var wg sync.WaitGroup
@@ -133,20 +133,20 @@ func TestAuditMiddleware_ThreadSafety(t *testing.T) {
 				url = "" // Mix enabled and disabled instances
 			}
 
-			var client auditpkg.AuditClient
+			var client audit.AuditClient
 			if url != "" {
 				client = newMockAuditClient(true)
 			} else {
 				client = newMockAuditClient(false)
 			}
-			auditpkg.InitializeGlobalAudit(client)
+			audit.InitializeGlobalAudit(client)
 		}(i)
 	}
 
 	wg.Wait()
 
 	// Verify that the global instance was set
-	globalMiddleware := auditpkg.GetGlobalAuditMiddleware()
+	globalMiddleware := audit.GetGlobalAuditMiddleware()
 	if globalMiddleware == nil {
 		t.Error("Expected global audit middleware to be set")
 	}
@@ -163,7 +163,7 @@ func TestAuditMiddleware_ThreadSafety(t *testing.T) {
 
 func TestLogAuditEvent_WithoutInitialization(t *testing.T) {
 	// Reset global state to ensure no global instance
-	auditpkg.ResetGlobalAuditMiddleware()
+	audit.ResetGlobalAuditMiddleware()
 
 	// Test LogAuditEvent when global middleware is not initialized
 	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
@@ -192,7 +192,7 @@ func TestLogAudit_SendsRequest(t *testing.T) {
 	defer server.Close()
 
 	// For this test, we need to use the real shared/audit client since we're testing HTTP
-	sharedClient := auditpkg.NewClient(server.URL)
+	sharedClient := audit.NewClient(server.URL)
 
 	// Create request with authenticated user in context
 	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)


### PR DESCRIPTION
## Summary

Migrates `portal-backend` off the local `replace`-based audit module (`github.com/gov-dx-sandbox/shared/audit`) to the published `github.com/OpenDIF/opendif-core/shared/audit`, and folds the nested `shared/utils` module into the main module. This aligns portal-backend with the other services (consent-engine, orchestration-engine) that already consume shared modules from the module proxy, removing local `replace` directives.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **`go.mod` / `go.sum`**: Removed the `replace` directives for `shared/audit`, `portal-backend/shared/utils`, and `portal-backend/models`; dropped the local `shared/utils` require. Added `github.com/OpenDIF/opendif-core/shared/audit` as a direct dependency (via the module proxy) and tidied.
- **`portal-backend/shared/utils/go.mod`**: Deleted — this package is now part of the main module rather than a nested module.
- **`main.go`**: Updated the audit import to `github.com/OpenDIF/opendif-core/shared/audit` and the `audit.NewClient` / `audit.InitializeGlobalAudit` references.
- **`v1/middleware/audit_middleware.go`**: Updated import; switched the `LogAudit` client type to `audit.Auditor`. Kept the `client == nil` guard so a nil audit client is skipped safely (the shared package documents nil as a supported "audit disabled" state) rather than panicking on `IsEnabled()`.
- **`v1/middleware/audit_middleware_test.go`**: Updated import path and type references to the published package.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. The nil-client path is covered by the existing `v1/middleware` tests. `go mod tidy` is stable (no drift).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Additional Notes

No functional change to audit behavior — this is a dependency-sourcing refactor. The `client == nil || !client.IsEnabled()` guard in `LogAudit` is intentionally retained: the published package documents a nil client as a valid "audit disabled" case, so dropping the nil check would risk a panic.