### PR TITLE
fix(consent-engine): rename .env.template to .env.example and refresh env vars

### DIFF
--- a/exchange/consent-engine/.env.example
+++ b/exchange/consent-engine/.env.example
@@ -20,6 +20,9 @@ DB_PASSWORD=password
 DB_NAME=consent_engine
 DB_SSLMODE=require
 
+# Auto-create tables on startup (true|false)
+RUN_MIGRATION=false
+
 # =============================================================================
 # Migration Configuration
 # =============================================================================


### PR DESCRIPTION
## Summary
- Rename `consent-engine/.env.template` → `consent-engine/.env.example` for a more conventional name.
- Refresh the template to match the env vars the service actually reads:
  - Add `HOST` (read by `internal/config`, was missing).
  - Add `RUN_MIGRATION` (read by `v1/database`, was missing).
  - Remove the stale `TEST_DB_*` / `TEST_USE_POSTGRES` block — nothing in the codebase reads these (tests use the standard `DB_*` vars).
- Update `consent-engine/.dockerignore` to reference `.env.example`.

## Notes
- No code, Dockerfile, or docs reference `consent-engine/.env.template` by name, so the rename breaks nothing.
- The Dockerfile is multi-stage and the final image only receives the compiled binary, so build/image output is unaffected.

## Test plan
- [ ] `docker build` of consent-engine still succeeds.
- [ ] `.env.example` lists every env var the service reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)