### PR TITLE
fix(consent-engine): make JWT verifier IdP-agnostic

### DIFF
--- a/exchange/consent-engine/internal/config/config.go
+++ b/exchange/consent-engine/internal/config/config.go
@@ -45,7 +45,7 @@ type IDPConfig struct {
 	Issuer   string
 	JwksUrl  string
 	Audience string
-	OrgName  string
+	ClientID string
 }
 
 // DBConfigs holds database configuration
@@ -76,11 +76,12 @@ func LoadConfig(serviceName string) *Config {
 	// Parse flags
 	flag.Parse()
 
-	// Reading IDP Configs
-	orgName := utils.GetEnvOrDefault("IDP_ORG_NAME", "YOUR_ORG_NAME")
-	userIssuer := utils.GetEnvOrDefault("IDP_ISSUER", "https://api.asgardeo.io/t/"+orgName+"/oauth2/token")
-	userAudience := utils.GetEnvOrDefault("IDP_AUDIENCE", "YOUR_AUDIENCE")
-	userJwksURL := utils.GetEnvOrDefault("IDP_JWKS_URL", "https://api.asgardeo.io/t/"+orgName+"/oauth2/jwks")
+	// Reading IDP Configs (generic across IdPs; each check is applied by the
+	// verifier only when its value is configured)
+	userIssuer := utils.GetEnvOrDefault("IDP_ISSUER", "")
+	userAudience := utils.GetEnvOrDefault("IDP_AUDIENCE", "")
+	userJwksURL := utils.GetEnvOrDefault("IDP_JWKS_URL", "")
+	userClientID := utils.GetEnvOrDefault("IDP_CLIENT_ID", "")
 
 	// Reading DB Configs
 	dbHost := utils.GetEnvOrDefault("DB_HOST", "localhost")
@@ -122,7 +123,7 @@ func LoadConfig(serviceName string) *Config {
 			Issuer:   userIssuer,
 			JwksUrl:  userJwksURL,
 			Audience: userAudience,
-			OrgName:  orgName,
+			ClientID: userClientID,
 		},
 		DBConfigs: DBConfigs{
 			Host:     dbHost,

--- a/exchange/consent-engine/main.go
+++ b/exchange/consent-engine/main.go
@@ -78,16 +78,16 @@ func main() {
 	v1PortalHandler := v1handlers.NewPortalHandler(v1ConsentService)
 
 	slog.Info("JWT verifier configuration",
-		"org_name", cfg.IDPConfig.OrgName,
+		"client_id", cfg.IDPConfig.ClientID,
 		"issuer", cfg.IDPConfig.Issuer,
 		"audience", cfg.IDPConfig.Audience,
 		"jwks_url", cfg.IDPConfig.JwksUrl)
 
 	v1JWTVerifier, err := v1auth.NewJWTVerifier(v1auth.JWTVerifierConfig{
-		JWKSUrl:      cfg.IDPConfig.JwksUrl,
-		Issuer:       cfg.IDPConfig.Issuer,
-		Audience:     cfg.IDPConfig.Audience,
-		Organization: cfg.IDPConfig.OrgName,
+		JWKSUrl:  cfg.IDPConfig.JwksUrl,
+		Issuer:   cfg.IDPConfig.Issuer,
+		Audience: cfg.IDPConfig.Audience,
+		ClientID: cfg.IDPConfig.ClientID,
 	})
 	if err != nil {
 		slog.Error("Failed to initialize V1 JWT verifier", "error", err)

--- a/exchange/consent-engine/v1/auth/jwt_verifier.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier.go
@@ -248,7 +248,7 @@ func (jv *JWTVerifier) VerifyToken(tokenString string) (*jwt.Token, error) {
 			cid, _ = claims["azp"].(string)
 		}
 		if cid != jv.config.ClientID {
-			return nil, fmt.Errorf("invalid client_id: expected %s, got %v", jv.config.ClientID, claims["client_id"])
+			return nil, fmt.Errorf("invalid client_id: expected %s, got %q", jv.config.ClientID, cid)
 		}
 	}
 

--- a/exchange/consent-engine/v1/auth/jwt_verifier.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier.go
@@ -30,12 +30,14 @@ type JSONWebKey struct {
 	E   string `json:"e"`   // Exponent
 }
 
-// JWTVerifierConfig holds configuration for the JWT verifier
+// JWTVerifierConfig holds configuration for the JWT verifier.
+// Each check is applied only when its value is configured (non-empty), so the
+// verifier stays generic across identity providers.
 type JWTVerifierConfig struct {
-	JWKSUrl      string
-	Issuer       string
-	Audience     string
-	Organization string
+	JWKSUrl  string
+	Issuer   string
+	Audience string
+	ClientID string
 }
 
 // JWTVerifier handles JWT token verification
@@ -199,67 +201,54 @@ func (jv *JWTVerifier) getPublicKey(kid string) (*rsa.PublicKey, error) {
 	return key, nil
 }
 
-// VerifyToken verifies a JWT token and returns the parsed token
+// VerifyToken verifies a JWT token and returns the parsed token.
+//
+// Standard registered claims are validated by the jwt/v5 parser: the RS256
+// signing method, the signature (via the JWKS key func), expiry/not-before, and
+// — when configured — the issuer and audience. Audience validation natively
+// accepts both the string and array (RFC 7519) forms. The only non-standard,
+// optional check is client_id; there is deliberately no IdP-specific claim (e.g.
+// organization) so the verifier stays generic across identity providers.
 func (jv *JWTVerifier) VerifyToken(tokenString string) (*jwt.Token, error) {
-	// Parse and verify the token
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		// Verify signing method
-		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-
-		// Get key ID from token header
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
 		kid, ok := token.Header["kid"].(string)
 		if !ok {
 			return nil, fmt.Errorf("token missing 'kid' header")
 		}
-
-		// Get the public key
 		return jv.getPublicKey(kid)
-	})
+	}
+
+	// Build parser options; issuer/audience are enforced only when configured.
+	opts := []jwt.ParserOption{jwt.WithValidMethods([]string{"RS256"})}
+	if jv.config.Issuer != "" {
+		opts = append(opts, jwt.WithIssuer(jv.config.Issuer))
+	}
+	if jv.config.Audience != "" {
+		opts = append(opts, jwt.WithAudience(jv.config.Audience))
+	}
+
+	token, err := jwt.Parse(tokenString, keyFunc, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("token verification failed: %w", err)
 	}
-
 	if !token.Valid {
 		return nil, fmt.Errorf("token is invalid")
 	}
 
-	// Verify claims
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, fmt.Errorf("invalid token claims")
 	}
 
-	issVal, ok := claims["iss"]
-	if !ok {
-		return nil, fmt.Errorf("issuer (iss) claim is missing")
-	}
-	iss, ok := issVal.(string)
-	if !ok {
-		return nil, fmt.Errorf("issuer (iss) claim is not a string: got type %T", issVal)
-	}
-	if iss != jv.config.Issuer {
-		return nil, fmt.Errorf("invalid issuer: expected %s, got %s", jv.config.Issuer, iss)
-	}
-
-	// Verify audience
-	if audVal, ok := claims["aud"]; !ok {
-		return nil, fmt.Errorf("audience (aud) claim is missing")
-	} else {
-		aud, ok := audVal.(string)
-		if !ok {
-			return nil, fmt.Errorf("audience (aud) claim is not a string: got type %T", audVal)
+	// Verify client_id when configured. Prefer the "client_id" claim, falling
+	// back to "azp" for IdPs that use it.
+	if jv.config.ClientID != "" {
+		cid, _ := claims["client_id"].(string)
+		if cid == "" {
+			cid, _ = claims["azp"].(string)
 		}
-		if aud != jv.config.Audience {
-			return nil, fmt.Errorf("invalid audience: expected %s, got %s", jv.config.Audience, aud)
-		}
-	}
-
-	// Verify organization if specified
-	if jv.config.Organization != "" {
-		if org, ok := claims["org_name"].(string); !ok || org != jv.config.Organization {
-			return nil, fmt.Errorf("invalid organization: expected %s, got %v", jv.config.Organization, claims["org_name"])
+		if cid != jv.config.ClientID {
+			return nil, fmt.Errorf("invalid client_id: expected %s, got %v", jv.config.ClientID, claims["client_id"])
 		}
 	}
 

--- a/exchange/consent-engine/v1/auth/jwt_verifier_test.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier_test.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testKID = "test-key-1"
+
+// newTestVerifier spins up a mock JWKS server serving the public half of a
+// freshly generated RSA keypair, and returns a verifier wired to it plus the
+// private key used to sign test tokens.
+func newTestVerifier(t *testing.T, cfg JWTVerifierConfig) (*JWTVerifier, *rsa.PrivateKey) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwks := JWKS{Keys: []JSONWebKey{{
+		Kid: testKID,
+		Kty: "RSA",
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(priv.PublicKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(priv.PublicKey.E)).Bytes()),
+	}}}
+	body, err := json.Marshal(jwks)
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg.JWKSUrl = srv.URL
+	v, err := NewJWTVerifier(cfg)
+	require.NoError(t, err)
+	return v, priv
+}
+
+// signToken signs claims with the given key and the test kid.
+func signToken(t *testing.T, priv *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = testKID
+	s, err := tok.SignedString(priv)
+	require.NoError(t, err)
+	return s
+}
+
+// baseClaims returns a valid ThunderID-shaped claim set (string aud, no org_name).
+func baseClaims() jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":       "https://thunderid:8090",
+		"aud":       "CONSENT_PORTAL_APP",
+		"client_id": "CONSENT_PORTAL_APP",
+		"email":     "nayana@opensource.lk",
+		"sub":       "user-123",
+		"iat":       now.Unix(),
+		"nbf":       now.Unix(),
+		"exp":       now.Add(time.Hour).Unix(),
+	}
+}
+
+func fullConfig() JWTVerifierConfig {
+	return JWTVerifierConfig{
+		Issuer:   "https://thunderid:8090",
+		Audience: "CONSENT_PORTAL_APP",
+		ClientID: "CONSENT_PORTAL_APP",
+	}
+}
+
+func TestVerifyToken_ThunderIDShapedTokenPasses(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	email, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, baseClaims()))
+	require.NoError(t, err)
+	assert.Equal(t, "nayana@opensource.lk", email)
+}
+
+func TestVerifyToken_AudienceAsArrayPasses(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	claims["aud"] = []string{"other-app", "CONSENT_PORTAL_APP"}
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.NoError(t, err)
+}
+
+func TestVerifyToken_OrgClaimIsIgnored(t *testing.T) {
+	// A token carrying an org_name claim must still be accepted — the verifier
+	// is IdP-generic and does not look at organization.
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	claims["org_name"] = "SomeOtherOrg"
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.NoError(t, err)
+}
+
+func TestVerifyToken_WrongIssuerFails(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	claims["iss"] = "https://evil.example.com"
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.Error(t, err)
+}
+
+func TestVerifyToken_WrongAudienceFails(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	claims["aud"] = "SOME_OTHER_APP"
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.Error(t, err)
+}
+
+func TestVerifyToken_WrongClientIDFails(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	claims["client_id"] = "SOME_OTHER_APP"
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.Error(t, err)
+}
+
+func TestVerifyToken_ClientIDAzpFallback(t *testing.T) {
+	// When client_id is absent but azp carries it, the check should pass.
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	delete(claims, "client_id")
+	claims["azp"] = "CONSENT_PORTAL_APP"
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.NoError(t, err)
+}
+
+func TestVerifyToken_ClientIDCheckSkippedWhenUnconfigured(t *testing.T) {
+	cfg := fullConfig()
+	cfg.ClientID = "" // not configured -> skip client_id check entirely
+	v, priv := newTestVerifier(t, cfg)
+	claims := baseClaims()
+	claims["client_id"] = "anything-goes"
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.NoError(t, err)
+}
+
+func TestVerifyToken_ExpiredTokenFails(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	_, err := v.VerifyToken(signToken(t, priv, claims))
+	assert.Error(t, err)
+}
+
+func TestVerifyToken_NonRSAMethodFails(t *testing.T) {
+	v, _ := newTestVerifier(t, fullConfig())
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, baseClaims())
+	tok.Header["kid"] = testKID
+	signed, err := tok.SignedString([]byte("symmetric-secret"))
+	require.NoError(t, err)
+	_, err = v.VerifyToken(signed)
+	assert.Error(t, err)
+}
+
+func TestVerifyTokenAndExtractEmail_MissingEmailFails(t *testing.T) {
+	v, priv := newTestVerifier(t, fullConfig())
+	claims := baseClaims()
+	delete(claims, "email")
+	_, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, claims))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Problem

The consent-engine JWT verifier hard-codes a WSO2/Asgardeo-specific `org_name` claim check. Tokens issued by other identity providers (e.g. ThunderID) carry no organization claim, so they are rejected at the portal endpoints with:

```
Token verification failed: invalid organization: expected <org>, got <nil>
```

The verifier also only accepted a **string** `aud` (not the RFC 7519 array form) and performed no `client_id` check.

## Change

Make the verifier generic and simple — validate the standard OIDC claims and drop all IdP-specific ones:

- **Drop the organization check** and its config (`IDPConfig.OrgName` / `IDP_ORG_NAME`) entirely.
- **Validate issuer + audience via `golang-jwt/v5` parser options** (`WithIssuer`, `WithAudience`, `WithValidMethods(RS256)`). `WithAudience` natively accepts both the string and array forms, fixing the array-`aud` gap. Each check is applied only when configured.
- **Add an optional `client_id` check** (`IDP_CLIENT_ID`), with an `azp` fallback, enforced only when configured.
- Neutralize the `asgardeo.io`-derived default URLs in config.
- The middleware contract (`VerifyTokenAndExtractEmail`) is unchanged, so no changes to middleware/router/handlers.

### Env var changes
| Before | After |
| --- | --- |
| `IDP_ORG_NAME` (+ org check) | removed |
| — | `IDP_CLIENT_ID` (optional) |

`IDP_ISSUER`, `IDP_AUDIENCE`, `IDP_JWKS_URL` unchanged.

## Tests

Adds `v1/auth/jwt_verifier_test.go` (mock JWKS server + locally-signed RS256 tokens) covering: valid token, `aud` as array, wrong issuer/audience/client_id, `azp` fallback, client_id skip-when-unconfigured, expiry, non-RSA method, missing email, and — explicitly — that a token carrying an `org_name` claim is still accepted (proving org-independence).

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.