### PR TITLE
fix: standardize application identity to client_id (#447)

### DIFF
--- a/exchange/orchestration-engine/auth/token.go
+++ b/exchange/orchestration-engine/auth/token.go
@@ -520,29 +520,12 @@ func parseAndValidateToken(tokenString string, trustUpstream bool, validator *To
 }
 
 // GetConsumerJwtFromToken validates and parses JWT token from HTTP request
-func GetConsumerJwtFromToken(env string, jwtConfig *configs.JWTConfig, trustUpstream bool, r *http.Request) (*ConsumerAssertion, error) {
-	return GetConsumerJwtFromTokenWithValidator(env, jwtConfig, trustUpstream, r, nil)
+func GetConsumerJwtFromToken(jwtConfig *configs.JWTConfig, trustUpstream bool, r *http.Request) (*ConsumerAssertion, error) {
+	return GetConsumerJwtFromTokenWithValidator(jwtConfig, trustUpstream, r, nil)
 }
 
 // GetConsumerJwtFromTokenWithValidator validates and parses JWT token with optional cached validator
-func GetConsumerJwtFromTokenWithValidator(env string, jwtConfig *configs.JWTConfig, trustUpstream bool, r *http.Request, validator *TokenValidator) (*ConsumerAssertion, error) {
-	if env == "development" {
-		// Return dummy values in local environment / development for ease of testing
-		// Bypass all validation and parsing
-		// WARNING: This should NEVER be used in production
-		// TODO: Remove this bypass by implementing proper test token generation and validation
-		logger.Log.Warn("Using development mode bypass for token validation")
-		return &ConsumerAssertion{
-			ApplicationID: "passport-app",
-			ClientID:      "passport-app",
-			Subscriber:    "passport-app",
-			Iss:           "https://idp.example.com",
-			Aud:           []string{"https://api.example.com"},
-			Exp:           time.Now().Add(time.Hour).Unix(),
-			Iat:           time.Now().Unix(),
-		}, nil
-	}
-
+func GetConsumerJwtFromTokenWithValidator(jwtConfig *configs.JWTConfig, trustUpstream bool, r *http.Request, validator *TokenValidator) (*ConsumerAssertion, error) {
 	// Extract token from request
 	tokenString, err := extractTokenFromRequest(r)
 	if err != nil {
@@ -580,17 +563,14 @@ func GetConsumerJwtFromTokenWithValidator(env string, jwtConfig *configs.JWTConf
 		return nil, err
 	}
 
-	// Extract application_id if present, otherwise use client_id as fallback
-	// TODO: In the future, ApplicationID should be fetched from an internal token service
-	// that maps client_id to application_id. For now, we use client_id as a fallback.
-	applicationID, ok := claims[ClaimApplicationId].(string)
-	if !ok || applicationID == "" {
-		applicationID = clientID // Use client_id when application_id is not present
-	}
+	// The application identity used across the exchange is standardized on the OIDC
+	// client_id. The PDP allow-list is keyed by client_id (see portal-backend
+	// application_service.go), so OE presents the same client_id when asking the PDP
+	// for a decision. See issue #447.
 
 	// Build and return ConsumerAssertion
 	return &ConsumerAssertion{
-		ApplicationID: applicationID,
+		ApplicationID: clientID,
 		ClientID:      clientID,
 		Subscriber:    subscriber,
 		Iss:           iss,

--- a/exchange/orchestration-engine/auth/token_test.go
+++ b/exchange/orchestration-engine/auth/token_test.go
@@ -28,32 +28,6 @@ func createUnsignedTestToken(claims jwt.MapClaims) string {
 	return tokenString
 }
 
-func TestGetConsumerJwtFromToken_LocalEnvironment(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-
-	result, err := GetConsumerJwtFromToken("development", nil, true, req)
-	if err != nil {
-		t.Errorf("Expected no error in development environment, got: %v", err)
-	}
-
-	if result == nil {
-		t.Fatal("Expected non-nil result in development environment")
-	}
-
-	expected := &ConsumerAssertion{
-		ClientID:   "passport-app",
-		Subscriber: "passport-app",
-		Iss:        "https://idp.example.com",
-	}
-
-	if result.ClientID != expected.ClientID {
-		t.Errorf("Expected ClientID %s, got %s", expected.ClientID, result.ClientID)
-	}
-	if result.Subscriber != expected.Subscriber {
-		t.Errorf("Expected Subscriber %s, got %s", expected.Subscriber, result.Subscriber)
-	}
-}
-
 func TestGetConsumerJwtFromToken_AuthorizationHeader(t *testing.T) {
 	claims := jwt.MapClaims{
 		ClaimIss:      "https://idp.test.com",
@@ -69,7 +43,7 @@ func TestGetConsumerJwtFromToken_AuthorizationHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}
@@ -93,7 +67,7 @@ func TestGetConsumerJwtFromToken_MissingAuthorizationHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	// No Authorization header set
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when Authorization header is missing")
@@ -110,7 +84,7 @@ func TestGetConsumerJwtFromToken_InvalidBearerScheme(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Basic sometoken")
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when Bearer scheme is not used")
@@ -127,7 +101,7 @@ func TestGetConsumerJwtFromToken_EmptyToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer ")
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when token is empty")
@@ -147,7 +121,7 @@ func TestGetConsumerJwtFromToken_TokenSizeLimit(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+largeToken)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when token exceeds size limit")
@@ -171,7 +145,7 @@ func TestGetConsumerJwtFromToken_MissingClientId(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when client_id is missing")
@@ -192,7 +166,7 @@ func TestGetConsumerJwtFromToken_ExpiredToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when token is expired")
@@ -214,7 +188,7 @@ func TestGetConsumerJwtFromToken_NbfFuture(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when token is not yet valid (nbf)")
@@ -237,7 +211,7 @@ func TestGetConsumerJwtFromToken_AzpFallback(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}
@@ -259,7 +233,7 @@ func TestGetConsumerJwtFromToken_MissingExp(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when exp claim is missing")
@@ -344,7 +318,7 @@ func TestGetConsumerJwtFromToken_InvalidTemporalClaimTypes(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			req.Header.Set("Authorization", "Bearer "+tokenString)
 
-			result, err := GetConsumerJwtFromToken("production", nil, true, req)
+			result, err := GetConsumerJwtFromToken(nil, true, req)
 
 			if err == nil {
 				t.Errorf("Expected error for %s", tc.name)
@@ -376,7 +350,7 @@ func TestGetConsumerJwtFromToken_InvalidIssuer(t *testing.T) {
 		ExpectedIssuer: "https://expected-issuer.com",
 	}
 
-	result, err := GetConsumerJwtFromToken("production", jwtConfig, true, req)
+	result, err := GetConsumerJwtFromToken(jwtConfig, true, req)
 
 	if err == nil {
 		t.Error("Expected error when issuer doesn't match")
@@ -403,7 +377,7 @@ func TestGetConsumerJwtFromToken_InvalidAudience(t *testing.T) {
 		ValidAudiences: []string{"https://api1.com", "https://api2.com"},
 	}
 
-	result, err := GetConsumerJwtFromToken("production", jwtConfig, true, req)
+	result, err := GetConsumerJwtFromToken(jwtConfig, true, req)
 
 	if err == nil {
 		t.Error("Expected error when audience doesn't match any valid audience")
@@ -430,7 +404,7 @@ func TestGetConsumerJwtFromToken_StringAudience(t *testing.T) {
 		ValidAudiences: []string{"https://api-string.com"},
 	}
 
-	result, err := GetConsumerJwtFromToken("production", jwtConfig, true, req)
+	result, err := GetConsumerJwtFromToken(jwtConfig, true, req)
 	if err != nil {
 		t.Errorf("Expected no error for string audience, got: %v", err)
 	}
@@ -454,7 +428,7 @@ func TestGetConsumerJwtFromToken_MissingSubscriber(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when both sub and azp are missing")
@@ -479,7 +453,7 @@ func TestGetConsumerJwtFromToken_EmptyClientId(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 
 	if err == nil {
 		t.Error("Expected error when client_id is empty")
@@ -492,12 +466,11 @@ func TestGetConsumerJwtFromToken_EmptyClientId(t *testing.T) {
 	}
 }
 
-func TestGetConsumerJwtFromToken_ApplicationIdFallback(t *testing.T) {
+func TestGetConsumerJwtFromToken_ApplicationIDIsClientID(t *testing.T) {
 	claims := jwt.MapClaims{
 		ClaimClientId: "test-client",
 		ClaimSub:      "subscriber",
 		ClaimExp:      float64(time.Now().Add(time.Hour).Unix()),
-		// Missing application_id - should fall back to client_id
 	}
 
 	tokenString := createUnsignedTestToken(claims)
@@ -505,7 +478,7 @@ func TestGetConsumerJwtFromToken_ApplicationIdFallback(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}
@@ -513,11 +486,13 @@ func TestGetConsumerJwtFromToken_ApplicationIdFallback(t *testing.T) {
 		t.Fatal("Expected non-nil result")
 	}
 	if result.ApplicationID != "test-client" {
-		t.Errorf("Expected ApplicationID to fallback to client_id 'test-client', got '%s'", result.ApplicationID)
+		t.Errorf("Expected ApplicationID to equal client_id 'test-client', got '%s'", result.ApplicationID)
 	}
 }
 
-func TestGetConsumerJwtFromToken_ApplicationIdPresent(t *testing.T) {
+// The application identity is standardized on client_id; any application_id claim
+// in the token is intentionally ignored (see issue #447).
+func TestGetConsumerJwtFromToken_ApplicationIdClaimIgnored(t *testing.T) {
 	claims := jwt.MapClaims{
 		ClaimClientId:      "test-client",
 		ClaimApplicationId: "test-app-123",
@@ -530,15 +505,15 @@ func TestGetConsumerJwtFromToken_ApplicationIdPresent(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}
 	if result == nil {
 		t.Fatal("Expected non-nil result")
 	}
-	if result.ApplicationID != "test-app-123" {
-		t.Errorf("Expected ApplicationID 'test-app-123', got '%s'", result.ApplicationID)
+	if result.ApplicationID != "test-client" {
+		t.Errorf("Expected ApplicationID to equal client_id 'test-client' (application_id ignored), got '%s'", result.ApplicationID)
 	}
 }
 
@@ -559,7 +534,7 @@ func TestGetConsumerJwtFromToken_MissingIssuerWhenRequired(t *testing.T) {
 		ExpectedIssuer: "https://required-issuer.com",
 	}
 
-	result, err := GetConsumerJwtFromToken("production", jwtConfig, true, req)
+	result, err := GetConsumerJwtFromToken(jwtConfig, true, req)
 
 	if err == nil {
 		t.Error("Expected error when issuer is required but missing")
@@ -589,7 +564,7 @@ func TestGetConsumerJwtFromToken_EmptyAudience(t *testing.T) {
 		ValidAudiences: []string{"https://api.com"},
 	}
 
-	result, err := GetConsumerJwtFromToken("production", jwtConfig, true, req)
+	result, err := GetConsumerJwtFromToken(jwtConfig, true, req)
 
 	if err == nil {
 		t.Error("Expected error when audience is empty but validation is required")
@@ -616,7 +591,7 @@ func TestGetConsumerJwtFromToken_NoAudienceValidationWhenNotConfigured(t *testin
 	req.Header.Set("Authorization", "Bearer "+tokenString)
 
 	// No jwtConfig means no audience validation
-	result, err := GetConsumerJwtFromToken("production", nil, true, req)
+	result, err := GetConsumerJwtFromToken(nil, true, req)
 	if err != nil {
 		t.Errorf("Expected no error when audience validation is not configured, got: %v", err)
 	}
@@ -947,7 +922,7 @@ func TestGetConsumerJwtFromTokenWithValidator_WithValidator(t *testing.T) {
 	// Create empty validator for trustUpstream=true scenario
 	validator := &TokenValidator{}
 
-	result, err := GetConsumerJwtFromTokenWithValidator("production", nil, true, req, validator)
+	result, err := GetConsumerJwtFromTokenWithValidator(nil, true, req, validator)
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
 	}

--- a/exchange/orchestration-engine/server/server.go
+++ b/exchange/orchestration-engine/server/server.go
@@ -144,7 +144,7 @@ func SetupRouter(f *federator.Federator) *chi.Mux {
 		}
 
 		// decode the token using the cached TokenValidator
-		consumerAssertion, err := auth.GetConsumerJwtFromTokenWithValidator(f.Configs.Environment, &f.Configs.JWT, f.Configs.TrustUpstream, r, f.TokenValidator)
+		consumerAssertion, err := auth.GetConsumerJwtFromTokenWithValidator(&f.Configs.JWT, f.Configs.TrustUpstream, r, f.TokenValidator)
 		if err != nil {
 			logger.Log.Error("Failed to get consumer JWT from token", "error", err)
 			// Return generic error to client to avoid exposing internal details

--- a/portal-backend/v1/services/application_service.go
+++ b/portal-backend/v1/services/application_service.go
@@ -75,8 +75,12 @@ func (s *ApplicationService) CreateApplication(ctx context.Context, req *models.
 	}
 
 	// Step 3: Update allow list in PDP (Saga Pattern)
+	// The allow-list is keyed by the IdP OIDC client_id, not the portal's random
+	// ApplicationID UUID. This is the identifier the Orchestration Engine extracts
+	// from the IdP-issued token (via the client_id fallback) when asking the PDP for
+	// a decision, so both sides must agree on it. See issue #447.
 	policyReq := models.AllowListUpdateRequest{
-		ApplicationID: application.ApplicationID,
+		ApplicationID: *application.IdpClientID,
 		Records:       application.SelectedFields,
 		GrantDuration: models.GrantDurationTypeOneMonth, // Default duration
 	}

--- a/portal-backend/v1/services/application_service.go
+++ b/portal-backend/v1/services/application_service.go
@@ -79,6 +79,9 @@ func (s *ApplicationService) CreateApplication(ctx context.Context, req *models.
 	// ApplicationID UUID. This is the identifier the Orchestration Engine extracts
 	// from the IdP-issued token (via the client_id fallback) when asking the PDP for
 	// a decision, so both sides must agree on it. See issue #447.
+	if application.IdpClientID == nil {
+		return nil, fmt.Errorf("cannot update allow list: application IdpClientID is nil")
+	}
 	policyReq := models.AllowListUpdateRequest{
 		ApplicationID: *application.IdpClientID,
 		Records:       application.SelectedFields,

--- a/portal-backend/v1/services/application_service_test.go
+++ b/portal-backend/v1/services/application_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,9 +21,14 @@ func TestApplicationService_CreateApplication(t *testing.T) {
 		db, mock, cleanup := SetupMockDB(t)
 		defer cleanup()
 
-		// Mock PDP
+		// Mock PDP, capturing the allow-list request body so we can assert the key.
+		var capturedAllowList models.AllowListUpdateRequest
 		mockTransport := &MockRoundTripper{
 			RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+				if req.Body != nil {
+					body, _ := io.ReadAll(req.Body)
+					_ = json.Unmarshal(body, &capturedAllowList)
+				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewBufferString(`{"records": [{"id": "policy_1"}]}`)),
@@ -66,6 +72,10 @@ func TestApplicationService_CreateApplication(t *testing.T) {
 			assert.Equal(t, req.ApplicationName, resp.ApplicationName)
 			assert.Equal(t, req.MemberID, resp.MemberID)
 		}
+
+		// The PDP allow-list must be keyed by the IdP OIDC client_id (the identity OE
+		// presents from the token), not the portal's random ApplicationID UUID. See #447.
+		assert.Equal(t, "mock-client-id", capturedAllowList.ApplicationID)
 
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})


### PR DESCRIPTION
## Summary

Authorization always failed for real (IdP-issued) tokens because the application identifier written into the PDP allow-list did not match the identifier the Orchestration Engine (OE) presented when asking for a policy decision — they came from two different namespaces, so the allow-list lookup never hit. The only way to run the system was the OE development bypass, which hardcoded `"passport-app"` and required manually seeding that literal into the allow-list.

This PR standardizes the application identity on the OIDC `client_id` across portal-backend, OE, and the PDP allow-list, and removes the development bypass entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **portal-backend** (`v1/services/application_service.go`): seed the PDP allow-list keyed by `*application.IdpClientID` (the IdP OIDC `client_id`) instead of the portal's random `ApplicationID` UUID.
- **orchestration-engine** (`auth/token.go`):
  - Removed the `env == "development"` bypass that hardcoded a `"passport-app"` identity.
  - Dropped the now-unused `env` parameter from `GetConsumerJwtFromToken` / `GetConsumerJwtFromTokenWithValidator`.
  - `ApplicationID` is now always set to `client_id`; the `application_id` claim is no longer read.
- **orchestration-engine** (`server/server.go`): updated the caller to drop the `Environment` argument.
- **Tests**: removed the obsolete bypass test, repurposed the `application_id` claim tests to assert the claim is ignored and identity is `client_id`, and added a regression guard asserting the PDP allow-list request is keyed by the IdP `client_id`.

The identity chain now lines up:

```
IdP token client_id  ==  identifier OE sends to PDP  ==  PDP allow_list key
```

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

`go build`, `go vet`, and the full test suites pass for both `portal-backend` and `exchange/orchestration-engine`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Fixes #447

## Additional Notes

- Because OE no longer reads the `application_id` claim, the IdP (Asgardeo) must **not** be configured to emit that claim — the flow now relies entirely on `client_id`.
- The secondary bug noted in the issue (bypass gated on `"development"` vs the stack's `"local"` convention) is now moot, since the bypass has been removed altogether.

## Deployment Notes

Existing applications provisioned before this change have their allow-list entries keyed by the old `ApplicationID` UUID. They will need to be re-seeded under their `client_id` (or re-provisioned) to authorize with real tokens.
