### PR TITLE
feat(consent-engine): optional TLS skip-verify for JWKS fetch

### DIFF
--- a/exchange/.env.example
+++ b/exchange/.env.example
@@ -33,3 +33,14 @@ DB_NAME_CE=consent_engine
 DB_NAME_OE=orchestration_engine
 # Auto-create tables on startup
 RUN_MIGRATION=true
+
+# IDP Configuration (consent-engine JWT verification for portal endpoints)
+# The verifier validates issuer, audience, and client_id when each is set,
+# extracts the email claim, and is otherwise IdP-agnostic.
+IDP_ISSUER=
+IDP_AUDIENCE=
+IDP_CLIENT_ID=
+IDP_JWKS_URL=
+# Dev-only: skip TLS verification on the JWKS fetch (e.g. a self-signed local
+# IdP). Leave false in production.
+IDP_JWKS_INSECURE_SKIP_VERIFY=false

--- a/exchange/consent-engine/.env.example
+++ b/exchange/consent-engine/.env.example
@@ -31,7 +31,12 @@ RUN_MIGRATION=false
 # =============================================================================
 # IDP Configuration
 # =============================================================================
-IDP_ORG_NAME=YOUR_ORG_NAME
+# The verifier validates issuer, audience, and client_id when each is set,
+# extracts the email claim, and is otherwise IdP-agnostic (no organization claim).
 IDP_ISSUER=
-IDP_AUDIENCE=YOUR_AUDIENCE
+IDP_AUDIENCE=
+IDP_CLIENT_ID=
 IDP_JWKS_URL=
+# Dev-only: skip TLS verification on the JWKS fetch (e.g. a self-signed local
+# IdP). Leave false in production.
+IDP_JWKS_INSECURE_SKIP_VERIFY=false

--- a/exchange/consent-engine/internal/config/config.go
+++ b/exchange/consent-engine/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"flag"
+	"strconv"
 	"time"
 
 	"github.com/OpenDIF/opendif-core/exchange/shared/utils"
@@ -46,6 +47,9 @@ type IDPConfig struct {
 	JwksUrl  string
 	Audience string
 	ClientID string
+	// InsecureSkipVerify skips TLS verification on the JWKS fetch. Dev-only
+	// (e.g. a self-signed local IdP); leave false in production.
+	InsecureSkipVerify bool
 }
 
 // DBConfigs holds database configuration
@@ -82,6 +86,8 @@ func LoadConfig(serviceName string) *Config {
 	userAudience := utils.GetEnvOrDefault("IDP_AUDIENCE", "")
 	userJwksURL := utils.GetEnvOrDefault("IDP_JWKS_URL", "")
 	userClientID := utils.GetEnvOrDefault("IDP_CLIENT_ID", "")
+	// Dev-only: skip TLS verification on the JWKS fetch (self-signed local IdP).
+	jwksInsecureSkipVerify, _ := strconv.ParseBool(utils.GetEnvOrDefault("IDP_JWKS_INSECURE_SKIP_VERIFY", "false"))
 
 	// Reading DB Configs
 	dbHost := utils.GetEnvOrDefault("DB_HOST", "localhost")
@@ -120,10 +126,11 @@ func LoadConfig(serviceName string) *Config {
 			RateLimit:  *rateLimit,
 		},
 		IDPConfig: IDPConfig{
-			Issuer:   userIssuer,
-			JwksUrl:  userJwksURL,
-			Audience: userAudience,
-			ClientID: userClientID,
+			Issuer:             userIssuer,
+			JwksUrl:            userJwksURL,
+			Audience:           userAudience,
+			ClientID:           userClientID,
+			InsecureSkipVerify: jwksInsecureSkipVerify,
 		},
 		DBConfigs: DBConfigs{
 			Host:     dbHost,

--- a/exchange/consent-engine/main.go
+++ b/exchange/consent-engine/main.go
@@ -81,13 +81,15 @@ func main() {
 		"client_id", cfg.IDPConfig.ClientID,
 		"issuer", cfg.IDPConfig.Issuer,
 		"audience", cfg.IDPConfig.Audience,
-		"jwks_url", cfg.IDPConfig.JwksUrl)
+		"jwks_url", cfg.IDPConfig.JwksUrl,
+		"jwks_insecure_skip_verify", cfg.IDPConfig.InsecureSkipVerify)
 
 	v1JWTVerifier, err := v1auth.NewJWTVerifier(v1auth.JWTVerifierConfig{
-		JWKSUrl:  cfg.IDPConfig.JwksUrl,
-		Issuer:   cfg.IDPConfig.Issuer,
-		Audience: cfg.IDPConfig.Audience,
-		ClientID: cfg.IDPConfig.ClientID,
+		JWKSUrl:            cfg.IDPConfig.JwksUrl,
+		Issuer:             cfg.IDPConfig.Issuer,
+		Audience:           cfg.IDPConfig.Audience,
+		ClientID:           cfg.IDPConfig.ClientID,
+		InsecureSkipVerify: cfg.IDPConfig.InsecureSkipVerify,
 	})
 	if err != nil {
 		slog.Error("Failed to initialize V1 JWT verifier", "error", err)

--- a/exchange/consent-engine/v1/auth/jwt_verifier.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto/rsa"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -38,6 +39,10 @@ type JWTVerifierConfig struct {
 	Issuer   string
 	Audience string
 	ClientID string
+	// InsecureSkipVerify disables TLS certificate verification for the JWKS
+	// fetch. Intended only for local/dev IdPs using self-signed certs; leave
+	// false in production.
+	InsecureSkipVerify bool
 }
 
 // JWTVerifier handles JWT token verification
@@ -52,13 +57,19 @@ type JWTVerifier struct {
 
 // NewJWTVerifier creates a new JWT verifier instance
 func NewJWTVerifier(config JWTVerifierConfig) (*JWTVerifier, error) {
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	if config.InsecureSkipVerify {
+		httpClient.Transport = &http.Transport{
+			// #nosec G402 -- opt-in via config, dev-only for self-signed IdP certs; default is false.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+
 	verifier := &JWTVerifier{
-		config: config,
-		keys:   make(map[string]*rsa.PublicKey),
-		logger: slog.Default(),
-		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
-		},
+		config:     config,
+		keys:       make(map[string]*rsa.PublicKey),
+		logger:     slog.Default(),
+		httpClient: httpClient,
 	}
 
 	// Initial fetch of JWKS (non-blocking to prevent startup failure)

--- a/exchange/consent-engine/v1/auth/jwt_verifier.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier.go
@@ -59,10 +59,12 @@ type JWTVerifier struct {
 func NewJWTVerifier(config JWTVerifierConfig) (*JWTVerifier, error) {
 	httpClient := &http.Client{Timeout: 10 * time.Second}
 	if config.InsecureSkipVerify {
-		httpClient.Transport = &http.Transport{
-			// #nosec G402 -- opt-in via config, dev-only for self-signed IdP certs; default is false.
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
+		// Clone the default transport to preserve connection pooling, keep-alives
+		// and proxy settings, overriding only TLS verification.
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		// #nosec G402 -- opt-in via config, dev-only for self-signed IdP certs; default is false.
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		httpClient.Transport = transport
 	}
 
 	verifier := &JWTVerifier{

--- a/exchange/consent-engine/v1/auth/jwt_verifier_test.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier_test.go
@@ -175,3 +175,48 @@ func TestVerifyTokenAndExtractEmail_MissingEmailFails(t *testing.T) {
 	_, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, claims))
 	assert.Error(t, err)
 }
+
+// newTLSTestVerifier serves the JWKS over a self-signed HTTPS server (like a
+// dev IdP), so JWKS fetches fail TLS verification unless InsecureSkipVerify is set.
+func newTLSTestVerifier(t *testing.T, cfg JWTVerifierConfig) (*JWTVerifier, *rsa.PrivateKey) {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwks := JWKS{Keys: []JSONWebKey{{
+		Kid: testKID,
+		Kty: "RSA",
+		Use: "sig",
+		N:   base64.RawURLEncoding.EncodeToString(priv.PublicKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(priv.PublicKey.E)).Bytes()),
+	}}}
+	body, err := json.Marshal(jwks)
+	require.NoError(t, err)
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg.JWKSUrl = srv.URL
+	v, err := NewJWTVerifier(cfg)
+	require.NoError(t, err)
+	return v, priv
+}
+
+func TestVerifyToken_SelfSignedJWKSFailsWithoutSkipVerify(t *testing.T) {
+	cfg := fullConfig() // InsecureSkipVerify defaults to false
+	v, priv := newTLSTestVerifier(t, cfg)
+	_, err := v.VerifyToken(signToken(t, priv, baseClaims()))
+	assert.Error(t, err) // JWKS fetch fails TLS verification -> cannot verify
+}
+
+func TestVerifyToken_SelfSignedJWKSPassesWithSkipVerify(t *testing.T) {
+	cfg := fullConfig()
+	cfg.InsecureSkipVerify = true
+	v, priv := newTLSTestVerifier(t, cfg)
+	email, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, baseClaims()))
+	require.NoError(t, err)
+	assert.Equal(t, "nayana@opensource.lk", email)
+}

--- a/exchange/docker-compose.yml
+++ b/exchange/docker-compose.yml
@@ -84,6 +84,12 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - LOG_FORMAT=${LOG_FORMAT:-text}
       - CONSENT_PORTAL_URL=${CONSENT_PORTAL_URL:-http://localhost:5173}
+      # IDP configuration (JWT verification for portal endpoints)
+      - IDP_ISSUER=${IDP_ISSUER:-}
+      - IDP_AUDIENCE=${IDP_AUDIENCE:-}
+      - IDP_CLIENT_ID=${IDP_CLIENT_ID:-}
+      - IDP_JWKS_URL=${IDP_JWKS_URL:-}
+      - IDP_JWKS_INSECURE_SKIP_VERIFY=${IDP_JWKS_INSECURE_SKIP_VERIFY:-false}
       # Database configuration
       - DB_HOST=${DB_HOST:-postgres}
       - DB_PORT=${DB_PORT:-5432}


### PR DESCRIPTION
## Problem

The consent-engine fetches JWKS from the IdP over HTTPS to verify tokens. With a dev IdP that serves a **self-signed** cert (e.g. a local ThunderID), that fetch fails TLS verification (`x509: certificate signed by unknown authority` / hostname mismatch), so portal-endpoint auth breaks unless a custom cert + CA bundle are hand-mounted into the container.

APISIX (`ssl_verify: false`) and the DIE app (`rejectUnauthorized: false`) already skip verification against the same dev cert; the consent-engine had no equivalent escape hatch.

## Change

Add an opt-in `IDP_JWKS_INSECURE_SKIP_VERIFY` (bool, **default `false`**). When enabled, the verifier's JWKS HTTP client uses a transport with `InsecureSkipVerify: true`, so it can fetch keys from a self-signed dev IdP without any cert mounting. Defaults keep TLS verification on everywhere it isn't explicitly opted in.

- `auth`: `JWTVerifierConfig.InsecureSkipVerify` → wires an `InsecureSkipVerify` transport onto the JWKS `http.Client` when set (annotated `#nosec G402`, opt-in/dev-only).
- `config`: reads `IDP_JWKS_INSECURE_SKIP_VERIFY` into `IDPConfig`; `main.go` passes it through and logs it.
- **tests**: a self-signed `httptest.NewTLSServer` JWKS **fails** without the flag and **succeeds** with it.

### Docs / compose
- `consent-engine/.env.example`, `exchange/.env.example`, `exchange/docker-compose.yml`: document/wire `IDP_JWKS_INSECURE_SKIP_VERIFY`.
- Also cleans up `consent-engine/.env.example` to match the generic verifier from #450: drops the orphaned `IDP_ORG_NAME` and adds `IDP_CLIENT_ID` (these were stale after #450 removed the org check).

## Tests

`go build ./...`, `go vet ./...`, `go test ./...`, gofumpt/goimports/staticcheck/gosec (pre-commit) all pass.

## Notes

Follow-up to #450. Enables removing the custom ThunderID cert + CA-bundle mounts from the deployment (opendif-farajaland) once this ships.