### PR TITLE
chore(orchestration-engine): remove dead .env.production and exclude config.docker.json from image

### DIFF
--- a/exchange/orchestration-engine/.dockerignore
+++ b/exchange/orchestration-engine/.dockerignore
@@ -1,6 +1,7 @@
 # Orchestration Engine Config File and Config Template
 # (config is provided at runtime via mount/env, never baked into the image)
 config.example.json
+config.docker.json
 config.json
 
 # Go build files

--- a/exchange/orchestration-engine/.env.production
+++ b/exchange/orchestration-engine/.env.production
@@ -1,8 +1,0 @@
-# Production Environment
-ENVIRONMENT=production
-BUILD_VERSION=latest
-LOG_LEVEL=warn
-LOG_FORMAT=json
-PORT_PDP=8082
-PORT_CE=8081
-PORT_GATEWAY=8080


### PR DESCRIPTION
## Summary
Cleanup of orchestration-engine configuration files:

- **Delete `.env.production`** — dead config. The OE binary only reads `PORT` and `CONFIG_PATH`; every variable in this file (`ENVIRONMENT`, `LOG_LEVEL`, `LOG_FORMAT`, `PORT_PDP/CE`, `PORT_GATEWAY`) is unused, and nothing in the repo (compose, Choreo, scripts) referenced the file. It was a leftover from the old env-based scheme that predates `config.json`.
- **Add `config.docker.json` to `.dockerignore`** — like `config.json` and `config.example.json`, it's provided at runtime via mount and should never be baked into the image. Keeps the build context consistent and cache-stable.

## Notes
- Runtime behavior is unchanged: the OE image never contained config, and `config.docker.json` is still mounted read-only by `docker-compose.yml`.
- The dead `log`/`server`/`services`/`sdl` fields in the `Config` struct were intentionally left as-is for now (separate code cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)