### PR TITLE
fix(build): resolve hooks directory dynamically to support git submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,10 @@ install-hooks:
 		echo "❌ Error: .githooks directory not found"; \
 		exit 1; \
 	fi
-	@mkdir -p .git/hooks
-	@cp .githooks/pre-commit .git/hooks/pre-commit
-	@chmod +x .git/hooks/pre-commit
+	@HOOKS_DIR=$$(git rev-parse --git-path hooks 2>/dev/null || echo ".git/hooks"); \
+	mkdir -p "$$HOOKS_DIR"; \
+	cp .githooks/pre-commit "$$HOOKS_DIR/pre-commit"; \
+	chmod +x "$$HOOKS_DIR/pre-commit"
 	@echo "✅ Git hooks installed successfully"
 	@echo "📍 Pre-commit hook will now run automatically on every commit"
 	@echo "💡 To bypass temporarily, use: git commit --no-verify"

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,9 @@ install-hooks:
 		echo "❌ Error: .githooks directory not found"; \
 		exit 1; \
 	fi
-	@HOOKS_DIR=$$(git rev-parse --git-path hooks 2>/dev/null || echo ".git/hooks"); \
-	mkdir -p "$$HOOKS_DIR"; \
-	cp .githooks/pre-commit "$$HOOKS_DIR/pre-commit"; \
+	@HOOKS_DIR=$$(git rev-parse --git-path hooks 2>/dev/null || echo ".git/hooks") && \
+	mkdir -p "$$HOOKS_DIR" && \
+	cp .githooks/pre-commit "$$HOOKS_DIR/pre-commit" && \
 	chmod +x "$$HOOKS_DIR/pre-commit"
 	@echo "✅ Git hooks installed successfully"
 	@echo "📍 Pre-commit hook will now run automatically on every commit"


### PR DESCRIPTION
Resolves https://github.com/LSFLK/lsf-govtech-ndx/issues/7
## Summary
Resolve the setup failure when `opendif-core` is integrated as a git submodule inside a parent repository. In git submodule directories, the `.git` path is a file (containing a relative pointer to `.git/modules`) rather than a folder. The hardcoded target `mkdir -p .git/hooks` aborted the installation. This PR replaces that with dynamic hooks directory resolution with `git rev-parse`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Replace hardcoded `.git/hooks` with a dynamic path variable `HOOKS_DIR` resolved using `git rev-parse --git-path hooks 2>/dev/null || echo ".git/hooks"`

## Testing

- [x] I have tested this change locally (verified `make install-hooks` succeeds in standard workspace layout)
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass
