### PR TITLE
Fix build context

### DIFF
--- a/.github/workflows/consent-engine-publish.yml
+++ b/.github/workflows/consent-engine-publish.yml
@@ -58,7 +58,7 @@ jobs:
         id: build-push
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/consent-engine-validate.yml
+++ b/.github/workflows/consent-engine-validate.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: false
           load: true

--- a/.github/workflows/orchestration-engine-publish.yml
+++ b/.github/workflows/orchestration-engine-publish.yml
@@ -58,7 +58,7 @@ jobs:
         id: build-push
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/orchestration-engine-validate.yml
+++ b/.github/workflows/orchestration-engine-validate.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: false
           load: true

--- a/.github/workflows/policy-decision-point-publish.yml
+++ b/.github/workflows/policy-decision-point-publish.yml
@@ -58,7 +58,7 @@ jobs:
         id: build-push
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/policy-decision-point-validate.yml
+++ b/.github/workflows/policy-decision-point-validate.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ${{ env.SERVICE_PATH }}
           file: ${{ env.SERVICE_PATH }}/Dockerfile
           push: false
           load: true

--- a/exchange/consent-engine/Dockerfile
+++ b/exchange/consent-engine/Dockerfile
@@ -11,15 +11,14 @@ ARG GIT_COMMIT
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
 
-# Copy go mod files and shared dependencies
-COPY exchange/consent-engine/go.mod exchange/consent-engine/go.sum ./exchange/consent-engine/
-COPY exchange/shared/ /app/exchange/shared/
-
-WORKDIR /app/exchange/consent-engine
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+# Shared modules (github.com/OpenNDX/openndx-core/...) are now published and
+# fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 
 # Copy source code (this layer is invalidated only on code changes)
-COPY exchange/consent-engine/ ./
+COPY . .
 
 # Build the application with build info from consent-engine directory
 RUN CGO_ENABLED=0 GOOS=linux go build \

--- a/exchange/consent-engine/go.mod
+++ b/exchange/consent-engine/go.mod
@@ -3,8 +3,8 @@ module github.com/gov-dx-sandbox/exchange/consent-engine
 go 1.24.6
 
 require (
-	github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.0.0-20260702074442-13c5fdc4f37d
-	github.com/OpenNDX/openndx-core/exchange/shared/utils v0.0.0-20260702074442-13c5fdc4f37d
+	github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.1.0
+	github.com/OpenNDX/openndx-core/exchange/shared/utils v0.1.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
@@ -52,9 +52,4 @@ require (
 	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
-
-replace (
-	github.com/OpenNDX/openndx-core/exchange/shared/monitoring => ../shared/monitoring
-	github.com/OpenNDX/openndx-core/exchange/shared/utils => ../shared/utils
 )

--- a/exchange/consent-engine/go.sum
+++ b/exchange/consent-engine/go.sum
@@ -1,3 +1,7 @@
+github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.1.0 h1:eCCWowEV5xrCn+Fl6UyMKnTY9c6GZRiJUAp7rys6ax8=
+github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.1.0/go.mod h1:VgaYFteogJ2Zsid5pY/Q5qO8yb8mj7ocqoRqxSsb06c=
+github.com/OpenNDX/openndx-core/exchange/shared/utils v0.1.0 h1:1GK7/nLjPU6Rg0hva0cku1cNCzIvsMlUuBhFJnz7LgQ=
+github.com/OpenNDX/openndx-core/exchange/shared/utils v0.1.0/go.mod h1:Bxfg/TNBEhAWXWA0cQkTLUk7i5O6g9xcafS10l9zdA4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/exchange/orchestration-engine/Dockerfile
+++ b/exchange/orchestration-engine/Dockerfile
@@ -7,15 +7,14 @@ RUN apk add --no-cache git ca-certificates
 # Set working directory
 WORKDIR /app
 
-# Copy go mod files and shared dependencies
-COPY exchange/orchestration-engine/go.mod exchange/orchestration-engine/go.sum ./exchange/orchestration-engine/
-COPY exchange/shared/ /app/exchange/shared/
-
-WORKDIR /app/exchange/orchestration-engine
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+# Shared modules (github.com/OpenNDX/openndx-core/...) are now published and
+# fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 
 # Copy source code (this layer is invalidated only on code changes)
-COPY exchange/orchestration-engine/ ./
+COPY . .
 
 # Build the application
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o orchestration-engine .
@@ -33,7 +32,7 @@ RUN addgroup -g 1000 appuser && \
 WORKDIR /app
 
 # Copy binary from builder
-COPY --from=builder /app/exchange/orchestration-engine/orchestration-engine .
+COPY --from=builder /app/orchestration-engine .
 
 # Create config directory
 RUN mkdir -p /app/config && \

--- a/exchange/orchestration-engine/go.mod
+++ b/exchange/orchestration-engine/go.mod
@@ -5,7 +5,7 @@ go 1.24.6
 require (
 	github.com/LSFLK/argus/pkg/audit v0.0.0-20260622104753-c28bd76815b0
 	github.com/MicahParks/keyfunc/v3 v3.7.0
-	github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.0.0-20260702091746-b79410856362
+	github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.1.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
@@ -50,5 +50,3 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/OpenNDX/openndx-core/exchange/shared/monitoring => ../shared/monitoring

--- a/exchange/orchestration-engine/go.sum
+++ b/exchange/orchestration-engine/go.sum
@@ -4,6 +4,8 @@ github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOh
 github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
 github.com/MicahParks/keyfunc/v3 v3.7.0 h1:pdafUNyq+p3ZlvjJX1HWFP7MA3+cLpDtg69U3kITJGM=
 github.com/MicahParks/keyfunc/v3 v3.7.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
+github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.1.0 h1:eCCWowEV5xrCn+Fl6UyMKnTY9c6GZRiJUAp7rys6ax8=
+github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.1.0/go.mod h1:VgaYFteogJ2Zsid5pY/Q5qO8yb8mj7ocqoRqxSsb06c=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/exchange/policy-decision-point/Dockerfile
+++ b/exchange/policy-decision-point/Dockerfile
@@ -11,15 +11,14 @@ ARG GIT_COMMIT
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
 
-# Copy go mod files and shared dependencies
-COPY exchange/policy-decision-point/go.mod exchange/policy-decision-point/go.sum ./exchange/policy-decision-point/
-COPY exchange/shared/ /app/exchange/shared/
-
-WORKDIR /app/exchange/policy-decision-point
+# Copy go mod files first for better layer caching
+COPY go.mod go.sum ./
+# Shared modules (github.com/OpenNDX/openndx-core/...) are now published and
+# fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 
 # Copy source code (this layer is invalidated only on code changes)
-COPY exchange/policy-decision-point/ ./
+COPY . .
 
 # Build the application with build info
 RUN CGO_ENABLED=0 GOOS=linux go build \

--- a/exchange/policy-decision-point/go.mod
+++ b/exchange/policy-decision-point/go.mod
@@ -3,7 +3,7 @@ module github.com/gov-dx-sandbox/exchange/policy-decision-point
 go 1.24.6
 
 require (
-	github.com/OpenNDX/openndx-core/exchange/shared/utils v0.0.0-20260702054005-b41f3c6376d8
+	github.com/OpenNDX/openndx-core/exchange/shared/utils v0.1.0
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
 	gorm.io/driver/postgres v1.6.0
@@ -28,5 +28,3 @@ require (
 	golang.org/x/text v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/OpenNDX/openndx-core/exchange/shared/utils => ../shared/utils

--- a/exchange/policy-decision-point/go.sum
+++ b/exchange/policy-decision-point/go.sum
@@ -1,3 +1,5 @@
+github.com/OpenNDX/openndx-core/exchange/shared/utils v0.1.0 h1:1GK7/nLjPU6Rg0hva0cku1cNCzIvsMlUuBhFJnz7LgQ=
+github.com/OpenNDX/openndx-core/exchange/shared/utils v0.1.0/go.mod h1:Bxfg/TNBEhAWXWA0cQkTLUk7i5O6g9xcafS10l9zdA4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
CI on `main` branch failing, rectify per last working https://github.com/openndx/openndx-core/commit/5ed1f9dbfe28d9da2453a5d074f41fd3bbdcc415

## Changes Made
1. Revert Dockerfiles to their original structure where they build within their own service directory context (caching `go.mod`/`go.sum` and running `COPY . .` from the local service root, rather than copying `/exchange/shared/` from the repository root):
* exchange/consent-engine/Dockerfile
* exchange/orchestration-engine/Dockerfile
* exchange/policy-decision-point/Dockerfile

2. Update contexts for the 3 Go services in `exchange/docker-compose.yml` point locally inside their respective subdirectories
```yaml
  policy-decision-point:
    build:
      context: ./policy-decision-point
      dockerfile: Dockerfile
```

3. All workflow contexts inside `.github/workflows/*.yml` match the local service build context:
* `context: ${{ env.SERVICE_PATH }}`
* `file: ${{ env.SERVICE_PATH }}/Dockerfile`
