### PR TITLE
chore(shared): rename shared Go module paths to OpenNDX/openndx-core (1/2)

### DIFF
--- a/exchange/shared/config/go.mod
+++ b/exchange/shared/config/go.mod
@@ -1,3 +1,3 @@
-module github.com/OpenDIF/opendif-core/exchange/shared/config
+module github.com/OpenNDX/openndx-core/exchange/shared/config
 
 go 1.21

--- a/exchange/shared/constants/go.mod
+++ b/exchange/shared/constants/go.mod
@@ -1,3 +1,3 @@
-module github.com/OpenDIF/opendif-core/exchange/shared/constants
+module github.com/OpenNDX/openndx-core/exchange/shared/constants
 
 go 1.24.6

--- a/exchange/shared/monitoring/go.mod
+++ b/exchange/shared/monitoring/go.mod
@@ -1,4 +1,4 @@
-module github.com/OpenDIF/opendif-core/exchange/shared/monitoring
+module github.com/OpenNDX/openndx-core/exchange/shared/monitoring
 
 go 1.24.6
 

--- a/exchange/shared/utils/go.mod
+++ b/exchange/shared/utils/go.mod
@@ -1,3 +1,3 @@
-module github.com/OpenDIF/opendif-core/exchange/shared/utils
+module github.com/OpenNDX/openndx-core/exchange/shared/utils
 
 go 1.24.6

--- a/shared/audit/go.mod
+++ b/shared/audit/go.mod
@@ -1,3 +1,3 @@
-module github.com/OpenDIF/opendif-core/shared/audit
+module github.com/OpenNDX/openndx-core/shared/audit
 
 go 1.24.6


### PR DESCRIPTION
## What

Renames the **shared** Go modules' `module` declarations from `github.com/OpenDIF/opendif-core/...` to `github.com/OpenNDX/openndx-core/...`, to match the renamed repository:

- `exchange/shared/monitoring`
- `exchange/shared/utils`
- `exchange/shared/config`
- `exchange/shared/constants`
- `shared/audit`

Only the `module` line changes in each file (5 lines total). No shared module imports another, and none reference their own path internally.

## Why this is step 1 of 2

The service modules (`consent-engine`, `orchestration-engine`, `policy-decision-point`) consume `shared/monitoring` and `shared/utils` **via the Go module proxy** at pinned pseudo-versions. A consumer can't point at `github.com/OpenNDX/openndx-core/exchange/shared/...@<version>` until that version exists on `main` — so the shared rename has to land first.

**This PR is safe to merge on its own:** the existing consumers still `require` the `OpenDIF` path at pinned pseudo-versions, which resolve against the pre-rename commits (whose `go.mod` still says `OpenDIF`). `main` keeps building.

A **follow-up PR** will:
1. rename the leaf application modules (`consent-engine`, `policy-decision-point`, `portal-backend`, `tests/integration`, plus the already-prepared `orchestration-engine`), and
2. bump the consumer `require`/`import` edges to the new `OpenNDX/...` shared paths at the new pseudo-versions produced by merging this PR.

This keeps everything **proxy-based** — deliberately **no** `replace` directives and **no** Dockerfile/compose changes (that coupling was reverted in #473).

## Verification

- `go build ./...` passes for all 5 renamed modules; `go test ./...` passes for `utils` (monitoring/config/constants/audit have no or unaffected tests — see note).
- Consumers still `go build ./...` cleanly against their existing pinned `OpenDIF` versions.

## Note (pre-existing, out of scope)

`exchange/shared/monitoring` has a **pre-existing** failing unit test, `TestLooksLikeIDImprovedLogic` (`looksLikeID("12")` returns `true`, expected `false`). It fails identically on `main` before this change and is unrelated to the module-path rename — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
