### PR TITLE
chore: finish OpenNDX rebrand (remaining OpenDIF + Gov DX Sandbox references)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# OpenDIF Pre-commit Hook
+# OpenNDX Pre-commit Hook
 # Validates quality checks, builds, and tests for staged services only
 # Compatible with macOS default Bash 3.2+
 # Note: set -e is intentionally not used to allow graceful error handling
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-echo -e "${BLUE}=== OpenDIF Pre-commit Validation ===${NC}\n"
+echo -e "${BLUE}=== OpenNDX Pre-commit Validation ===${NC}\n"
 
 # Function to get service path by name
 # NOTE: This mapping must be kept in sync with the Makefile (lines 62-70)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: "🐞 Report a Bug"
-description: "Create new issue in LSFLK/OpenDIF: 🐞 Report a Bug"
+description: "Create new issue in LSFLK/OpenNDX: 🐞 Report a Bug"
 labels: ["Type/Bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/improvement_request.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_request.yml
@@ -1,5 +1,5 @@
 name: "🚀 Improvement Request"
-description: "Create new issue in LSFLK/OpenDIF: 🚀 Improvement Request"
+description: "Create new issue in LSFLK/OpenNDX: 🚀 Improvement Request"
 labels: ["Type/Improvement"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/new_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/new_feature_request.yml
@@ -1,5 +1,5 @@
 name: "💡 New Feature Request"
-description: "Create new issue in LSFLK/OpenDIF: 💡 New Feature Request"
+description: "Create new issue in LSFLK/OpenNDX: 💡 New Feature Request"
 labels: ["Type/New Feature"]
 body:
   - type: textarea

--- a/.github/workflows/admin-portal-publish.yml
+++ b/.github/workflows/admin-portal-publish.yml
@@ -43,7 +43,7 @@ jobs:
                       type=sha,format=long
                   labels: |
                       org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-                      org.opencontainers.image.description=Admin Portal for OpenDIF
+                      org.opencontainers.image.description=Admin Portal for OpenNDX
                       org.opencontainers.image.licenses=Apache-2.0
 
             - name: Build and push Docker image

--- a/.github/workflows/consent-portal-publish.yml
+++ b/.github/workflows/consent-portal-publish.yml
@@ -43,7 +43,7 @@ jobs:
                       type=sha,format=long
                   labels: |
                       org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-                      org.opencontainers.image.description=Consent Portal for OpenDIF
+                      org.opencontainers.image.description=Consent Portal for OpenNDX
                       org.opencontainers.image.licenses=Apache-2.0
 
             - name: Build and push Docker image

--- a/.github/workflows/member-portal-publish.yml
+++ b/.github/workflows/member-portal-publish.yml
@@ -43,7 +43,7 @@ jobs:
                       type=sha,format=long
                   labels: |
                       org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-                      org.opencontainers.image.description=Member Portal for OpenDIF
+                      org.opencontainers.image.description=Member Portal for OpenNDX
                       org.opencontainers.image.licenses=Apache-2.0
 
             - name: Build and push Docker image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to OpenDIF Core
+# Contributing to OpenNDX Core
 
-Thank you for your interest in contributing to the OpenDIF Core project! We welcome contributions from everyone and are grateful for your help in making this project better.
+Thank you for your interest in contributing to the OpenNDX Core project! We welcome contributions from everyone and are grateful for your help in making this project better.
 
 ## Code of Conduct
 
@@ -35,12 +35,12 @@ New to the project? Start with our [Development Guide](docs/contributing/develop
 
 If you have questions or want to discuss ideas:
 
--   Check our [Issues](https://github.com/OpenDIF/opendif-mvp/issues) to see if your question has been asked before
--   Open a new [Issue](https://github.com/OpenDIF/opendif-mvp/issues/new) for bugs or feature requests
--   Review open [Pull Requests](https://github.com/OpenDIF/opendif-mvp/pulls) to see what others are working on
+-   Check our [Issues](https://github.com/OpenNDX/openndx-core/issues) to see if your question has been asked before
+-   Open a new [Issue](https://github.com/OpenNDX/openndx-core/issues/new) for bugs or feature requests
+-   Review open [Pull Requests](https://github.com/OpenNDX/openndx-core/pulls) to see what others are working on
 
 ## Recognition
 
-Contributors will be recognized in our project documentation and release notes. Thank you for helping make OpenDIF Core better!
+Contributors will be recognized in our project documentation and release notes. Thank you for helping make OpenNDX Core better!
 
 We look forward to your contributions!

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-# OpenDIF - Comprehensive Makefile
+# OpenNDX - Comprehensive Makefile
 # This Makefile provides standardized commands for all services in the repository
 
 .PHONY: help install-hooks setup validate-build validate-test validate-docker-build check-lint run clean setup-all validate-build-all validate-test-all
 
 # Default target
 help:
-	@echo "OpenDIF - Available Commands"
+	@echo "OpenNDX - Available Commands"
 	@echo "=========================================="
 	@echo ""
 	@echo "Usage: make [COMMAND] [SERVICE]"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenDIF
+# OpenNDX
 
 A comprehensive data exchange platform consisting of multiple microservices and portals for secure data sharing and consent management.
 
@@ -13,8 +13,8 @@ A comprehensive data exchange platform consisting of multiple microservices and 
 
 ### Frontend Portals (React/TypeScript)
 
-- **Member Portal** - Management of `Data sources` or `Applications` by `OpenDIF Members`
-- **Admin Portal** - Administrative dashboard for the `OpenDIF Admins`
+- **Member Portal** - Management of `Data sources` or `Applications` by `OpenNDX Members`
+- **Admin Portal** - Administrative dashboard for the `OpenNDX Admins`
 - **Consent Portal** - Citizen-facing interface for data consent
 
 ### Optional Components
@@ -26,21 +26,21 @@ A comprehensive data exchange platform consisting of multiple microservices and 
 
 ### Prerequisites
 
-Before deploying OpenDIF, you must configure an Identity Provider (IdP) to handle authentication and authorization.
+Before deploying OpenNDX, you must configure an Identity Provider (IdP) to handle authentication and authorization.
 
 1.  **Configure IdP**: Set up an IdP (e.g., Asgardeo, Keycloak, Auth0) to manage users and roles.
 2.  **Create Users**: Create the necessary users in your IdP.
 3.  **Assign Roles**:
-    - Create a role named `opendif-admin`.
-    - Assign this role to users who require administrative access to the OpenDIF Admin Portal.
-    - Ensure other roles (e.g., `opendif-member`) are created and assigned as needed for Member Portal access.
+    - Create a role named `openndx-admin`.
+    - Assign this role to users who require administrative access to the OpenNDX Admin Portal.
+    - Ensure other roles (e.g., `openndx-member`) are created and assigned as needed for Member Portal access.
 
 ### Deployment Steps
 
 1.  **Clone the Repository**:
     ```bash
-    git clone https://github.com/OpenDIF/opendif-core.git
-    cd opendif-core
+    git clone https://github.com/OpenNDX/openndx-core.git
+    cd openndx-core
     ```
 
 2.  **Configure Environment**:

--- a/docs/LOCAL_CODE_QUALITY_SETUP.md
+++ b/docs/LOCAL_CODE_QUALITY_SETUP.md
@@ -1,10 +1,10 @@
 # Local Code Quality Setup Guide
 
-This guide describes how to set up and run comprehensive code quality checks locally for the OpenDIF MVP project.
+This guide describes how to set up and run comprehensive code quality checks locally for the OpenNDX MVP project.
 
 ## Overview
 
-The OpenDIF MVP project uses a comprehensive code quality system that includes:
+The OpenNDX MVP project uses a comprehensive code quality system that includes:
 
 - **Code Formatting** (gofumpt, goimports)
 - **Linting** (go vet, gofmt, staticcheck)
@@ -39,8 +39,8 @@ All quality checks are orchestrated through a centralized Makefile that automati
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/OpenDIF/opendif-mvp.git
-cd opendif-mvp
+git clone https://github.com/OpenNDX/openndx-core.git
+cd openndx-core
 ```
 
 ### 2. Install Go Quality Tools

--- a/docs/MAKEFILE_USAGE.md
+++ b/docs/MAKEFILE_USAGE.md
@@ -1,6 +1,6 @@
 # Makefile Usage Guide
 
-This guide provides a quick reference for all available Makefile commands in the OpenDIF MVP project.
+This guide provides a quick reference for all available Makefile commands in the OpenNDX MVP project.
 
 > 📚 **For detailed code quality setup and troubleshooting**, see [LOCAL_CODE_QUALITY_SETUP.md](LOCAL_CODE_QUALITY_SETUP.md)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,7 +24,7 @@ Go to **Actions** → **Release - Build and Publish All Services** → **Run wor
 
 ## Artifacts
 
-All images are published to **ghcr.io/opendif/opendif-core/**:
+All images are published to **ghcr.io/openndx/openndx-core/**:
 
 | Category | Service | Image Name |
 | :--- | :--- | :--- |
@@ -38,5 +38,5 @@ All images are published to **ghcr.io/opendif/opendif-core/**:
 
 ## Verification
 ```bash
-docker pull ghcr.io/opendif/opendif-core/portal-backend:v1.0.0
+docker pull ghcr.io/openndx/openndx-core/portal-backend:v1.0.0
 ```

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide will help you set up your local development environment for contributing to OpenDIF Core.
+This guide will help you set up your local development environment for contributing to OpenNDX Core.
 
 ## Prerequisites
 
@@ -15,13 +15,13 @@ Before you begin, ensure you have the following installed:
 
 1.  **Fork and clone the repository:**
     ```bash
-    git clone https://github.com/YOUR_USERNAME/opendif-mvp.git
-    cd opendif-mvp
+    git clone https://github.com/YOUR_USERNAME/openndx-core.git
+    cd openndx-core
     ```
 
 2.  **Add the upstream remote:**
     ```bash
-    git remote add upstream https://github.com/OpenDIF/opendif-mvp.git
+    git remote add upstream https://github.com/OpenNDX/openndx-core.git
     ```
 
 3.  **Run the setup script:**
@@ -121,7 +121,7 @@ Before submitting a pull request, ensure:
 ## Project Structure
 
 ```
-opendif-mvp/
+openndx-core/
 ├── exchange/              # Go backend services
 │   ├── orchestration-engine/
 │   ├── policy-decision-point/
@@ -138,7 +138,7 @@ opendif-mvp/
 
 ## Getting Help
 
--   Check existing [Issues](https://github.com/OpenDIF/opendif-mvp/issues)
+-   Check existing [Issues](https://github.com/OpenNDX/openndx-core/issues)
 -   Review [Pull Request Guidelines](pull-requests.md)
 -   See [Reporting Issues](reporting-issues.md) for bug reports
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -4,7 +4,7 @@ We welcome pull requests from the community! This guide will help ensure your co
 
 ## Before You Start
 
-1.   **Check for existing work:** Search [open pull requests](https://github.com/OpenDIF/opendif-mvp/pulls) to avoid duplicate work
+1.   **Check for existing work:** Search [open pull requests](https://github.com/OpenNDX/openndx-core/pulls) to avoid duplicate work
 2.   **Discuss major changes:** For significant changes, consider opening an issue first to discuss the approach
 3.   **Read the documentation:** Review the [Development Guide](development.md) to set up your environment
 
@@ -102,4 +102,4 @@ Before submitting, ensure:
 -   Check [Reporting Issues](reporting-issues.md) for bug reporting
 -   See [Code of Conduct](../../CODE_OF_CONDUCT.md) for community standards
 
-[View Open Pull Requests](https://github.com/OpenDIF/opendif-mvp/pulls)
+[View Open Pull Requests](https://github.com/OpenNDX/openndx-core/pulls)

--- a/docs/contributing/reporting-issues.md
+++ b/docs/contributing/reporting-issues.md
@@ -4,7 +4,7 @@ We use GitHub Issues to track bugs, feature requests, and improvements. Your det
 
 ## Before Creating an Issue
 
-1.   **Search existing issues:** Check [open issues](https://github.com/OpenDIF/opendif-mvp/issues) and [closed issues](https://github.com/OpenDIF/opendif-mvp/issues?q=is%3Aissue+is%3Aclosed) to see if your issue has already been reported
+1.   **Search existing issues:** Check [open issues](https://github.com/OpenNDX/openndx-core/issues) and [closed issues](https://github.com/OpenNDX/openndx-core/issues?q=is%3Aissue+is%3Aclosed) to see if your issue has already been reported
 2.   **Check documentation:** Review the README and relevant documentation to see if your question is answered
 3.   **Verify it's a bug:** For behavior questions, ensure it's actually a bug and not expected behavior
 
@@ -130,6 +130,6 @@ We use labels to categorize issues:
 
 ## Security Issues
 
-**Do not** report security vulnerabilities through public GitHub issues. Instead, please contact the maintainers directly or use GitHub's [private vulnerability reporting](https://github.com/OpenDIF/opendif-mvp/security/advisories/new) feature.
+**Do not** report security vulnerabilities through public GitHub issues. Instead, please contact the maintainers directly or use GitHub's [private vulnerability reporting](https://github.com/OpenNDX/openndx-core/security/advisories/new) feature.
 
-[Open a new issue](https://github.com/OpenDIF/opendif-mvp/issues/new)
+[Open a new issue](https://github.com/OpenNDX/openndx-core/issues/new)

--- a/exchange/consent-engine/Dockerfile
+++ b/exchange/consent-engine/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache git ca-certificates tzdata
 
 # Copy go mod files first for better layer caching
 COPY go.mod go.sum ./
-# Shared modules (github.com/OpenDIF/opendif-core/...) are now published and
+# Shared modules (github.com/OpenNDX/openndx-core/...) are now published and
 # fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 

--- a/exchange/consent-engine/v1/openapi.yaml
+++ b/exchange/consent-engine/v1/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Consent Engine API v1
   description: |
-    Handles consent creation, approval, and management for the OpenDIF Data Exchange Platform.
+    Handles consent creation, approval, and management for the OpenNDX Data Exchange Platform.
     
     ## API Structure
     The API is divided into two main categories:
@@ -25,7 +25,7 @@ info:
     - The email from the decoded token matches the consent owner's email
   version: 1.0.0
   contact:
-    name: OpenDIF Team
+    name: OpenNDX Team
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/exchange/docker-compose.yml
+++ b/exchange/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       start_period: 10s
     restart: unless-stopped
     networks:
-      - opendif-network
+      - openndx-network
 
   policy-decision-point:
     build:
@@ -65,7 +65,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     networks:
-      - opendif-network
+      - openndx-network
 
   consent-engine:
     build:
@@ -103,7 +103,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     networks:
-      - opendif-network
+      - openndx-network
 
   orchestration-engine:
     build:
@@ -150,7 +150,7 @@ services:
       start_period: 10s
     restart: unless-stopped
     networks:
-      - opendif-network
+      - openndx-network
 
   audit-service:
     build:
@@ -175,11 +175,11 @@ services:
         condition: service_healthy
     restart: unless-stopped
     networks:
-      - opendif-network
+      - openndx-network
 
 volumes:
   postgres-data:
 
 networks:
-  opendif-network:
-    name: opendif-network
+  openndx-network:
+    name: openndx-network

--- a/exchange/orchestration-engine/Dockerfile
+++ b/exchange/orchestration-engine/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 # Copy go mod files first for better layer caching
 COPY go.mod go.sum ./
-# Shared modules (github.com/OpenDIF/opendif-core/...) are now published and
+# Shared modules (github.com/OpenNDX/openndx-core/...) are now published and
 # fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 

--- a/exchange/orchestration-engine/HOW_TO_TEST.md
+++ b/exchange/orchestration-engine/HOW_TO_TEST.md
@@ -35,7 +35,7 @@ curl -X GET http://localhost:4000/health
 **Result**: **PASSED**
 ```json
 {
-  "message": "OpenDIF Server is Healthy!"
+  "message": "OpenNDX Server is Healthy!"
 }
 ```
 

--- a/exchange/orchestration-engine/openapi.yaml
+++ b/exchange/orchestration-engine/openapi.yaml
@@ -23,7 +23,7 @@ paths:
                   message:
                     type: string
                 example:
-                  message: "OpenDIF Server is Healthy!"
+                  message: "OpenNDX Server is Healthy!"
   /sdl:
     get:
       summary: Get active GraphQL SDL

--- a/exchange/orchestration-engine/server/server.go
+++ b/exchange/orchestration-engine/server/server.go
@@ -115,7 +115,7 @@ func SetupRouter(f *federator.Federator) *chi.Mux {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		resp := Response{Message: "OpenDIF Server is Healthy!"}
+		resp := Response{Message: "OpenNDX Server is Healthy!"}
 		w.Header().Set("Content-Type", "application/json")
 		err := json.NewEncoder(w).Encode(resp)
 		if err != nil {

--- a/exchange/orchestration-engine/server/server_internal_test.go
+++ b/exchange/orchestration-engine/server/server_internal_test.go
@@ -35,7 +35,7 @@ func TestSetupRouter_Health(t *testing.T) {
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "OpenDIF Server is Healthy!")
+	assert.Contains(t, w.Body.String(), "OpenNDX Server is Healthy!")
 }
 
 func TestSetupRouter_SDL_Endpoints(t *testing.T) {

--- a/exchange/orchestration-engine/server/server_test.go
+++ b/exchange/orchestration-engine/server/server_test.go
@@ -22,7 +22,7 @@ func TestHealthEndpoint(t *testing.T) {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		resp := Response{Message: "OpenDIF Server is Healthy!"}
+		resp := Response{Message: "OpenNDX Server is Healthy!"}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})
@@ -37,7 +37,7 @@ func TestHealthEndpoint(t *testing.T) {
 	var response Response
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Equal(t, "OpenDIF Server is Healthy!", response.Message)
+	assert.Equal(t, "OpenNDX Server is Healthy!", response.Message)
 }
 
 func TestHealthEndpoint_WrongMethod(t *testing.T) {
@@ -47,7 +47,7 @@ func TestHealthEndpoint_WrongMethod(t *testing.T) {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		resp := Response{Message: "OpenDIF Server is Healthy!"}
+		resp := Response{Message: "OpenNDX Server is Healthy!"}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})

--- a/exchange/policy-decision-point/Dockerfile
+++ b/exchange/policy-decision-point/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache git ca-certificates tzdata
 
 # Copy go mod files first for better layer caching
 COPY go.mod go.sum ./
-# Shared modules (github.com/OpenDIF/opendif-core/...) are now published and
+# Shared modules (github.com/OpenNDX/openndx-core/...) are now published and
 # fetched from the module proxy, so no local shared source needs to be copied.
 RUN go mod download
 

--- a/exchange/policy-decision-point/openapi.yaml
+++ b/exchange/policy-decision-point/openapi.yaml
@@ -7,8 +7,8 @@ info:
     The service uses database-driven metadata management and supports real-time policy updates.
   version: 1.0.0
   contact:
-    name: Gov DX Sandbox Team
-    email: support@gov-dx-sandbox.com
+    name: OpenNDX Team
+    email: support@openndx.dev
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/exchange/shared/monitoring/metrics.go
+++ b/exchange/shared/monitoring/metrics.go
@@ -31,7 +31,7 @@ func ensureInitialized() {
 		// Try to get service name from environment or use default
 		serviceName := os.Getenv("SERVICE_NAME")
 		if serviceName == "" {
-			serviceName = "opendif-service"
+			serviceName = "openndx-service"
 		}
 
 		config := DefaultConfig(serviceName)

--- a/exchange/shared/monitoring/otel_metrics.go
+++ b/exchange/shared/monitoring/otel_metrics.go
@@ -24,24 +24,24 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 )
 
-// Custom OpenTelemetry attributes for OpenDIF-specific metrics.
-// These attributes use the "opendif." namespace prefix to distinguish them
+// Custom OpenTelemetry attributes for OpenNDX-specific metrics.
+// These attributes use the "openndx." namespace prefix to distinguish them
 // from standard OpenTelemetry semantic conventions.
 //
 // Custom Attributes:
-//   - opendif.business.action: The business action being performed (e.g., "consent_created", "policy_decision")
-//   - opendif.business.outcome: The outcome of the business action (e.g., "success", "failure", "allow", "deny")
-//   - opendif.external.target: The target system/service for external calls (e.g., "postgres", "redis", "external-api")
-//   - opendif.external.operation: The operation type for external calls (e.g., "query", "insert", "get", "set")
+//   - openndx.business.action: The business action being performed (e.g., "consent_created", "policy_decision")
+//   - openndx.business.outcome: The outcome of the business action (e.g., "success", "failure", "allow", "deny")
+//   - openndx.external.target: The target system/service for external calls (e.g., "postgres", "redis", "external-api")
+//   - openndx.external.operation: The operation type for external calls (e.g., "query", "insert", "get", "set")
 //
 // Standard semantic conventions (from semconv package) are used for HTTP metrics:
 //   - http.method, http.route, http.status_code (via semconv.HTTPRequestMethodKey, etc.)
 const (
-	// Attribute keys for custom OpenDIF metrics
-	attrBusinessAction    = "opendif.business.action"
-	attrBusinessOutcome   = "opendif.business.outcome"
-	attrExternalTarget    = "opendif.external.target"
-	attrExternalOperation = "opendif.external.operation"
+	// Attribute keys for custom OpenNDX metrics
+	attrBusinessAction    = "openndx.business.action"
+	attrBusinessOutcome   = "openndx.business.outcome"
+	attrExternalTarget    = "openndx.external.target"
+	attrExternalOperation = "openndx.external.operation"
 )
 
 var (
@@ -253,7 +253,7 @@ func initializeInternal(ctx context.Context, config Config) error {
 	otel.SetMeterProvider(meterProvider)
 
 	// Create meter
-	meter := otel.Meter("opendif")
+	meter := otel.Meter("openndx")
 
 	// Create instruments
 	httpRequestsCounter, err = meter.Int64Counter(

--- a/observability/README.md
+++ b/observability/README.md
@@ -422,7 +422,7 @@ Services automatically initialize OpenTelemetry metrics when first used. No expl
 
 1. **For Exchange Services** - Use shared monitoring package:
    ```go
-   import "github.com/gov-dx-sandbox/exchange/shared/monitoring"
+   import "github.com/OpenNDX/openndx-core/exchange/shared/monitoring"
    
    mux.Handle("/metrics", monitoring.Handler())
    handler := monitoring.HTTPMetricsMiddleware(mux)
@@ -430,7 +430,7 @@ Services automatically initialize OpenTelemetry metrics when first used. No expl
 
 2. **For Portal Backend** - Use middleware package:
    ```go
-   import v1middleware "github.com/gov-dx-sandbox/portal-backend/v1/middleware"
+   import v1middleware "github.com/OpenNDX/openndx-core/portal-backend/v1/middleware"
    
    topLevelMux.Handle("/metrics", v1middleware.MetricsHandler())
    topLevelMux.Handle("/api/v1/", v1middleware.MetricsMiddleware(handler))

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,4 +1,4 @@
-# Observability Stack for OpenDIF Core
+# Observability Stack for OpenNDX Core
 
 Local development stack: **Go Services** → **OpenTelemetry** → **Prometheus** → **Grafana**
 
@@ -90,7 +90,7 @@ docker compose up -d
 
 **Prerequisites:**
 
-Ensure all Go services are running and connected to the `opendif-network`:
+Ensure all Go services are running and connected to the `openndx-network`:
 - Orchestration Engine (port 4000)
 - Consent Engine (port 8081)
 - Policy Decision Point (port 8082)
@@ -158,7 +158,7 @@ export OTEL_METRICS_EXPORTER=none
 | `OTEL_METRICS_EXPORTER` | Exporter type: `prometheus`, `otlp`, or `none` | `prometheus` | `otlp` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint URL (required for `otlp` exporter) | - | `https://api.datadoghq.com/api/v2/otlp` |
 | `OTEL_EXPORTER_OTLP_HEADERS` | OTLP headers (e.g., API keys). Format: `key1=value1,key2=value2` | - | `DD-API-KEY=xxx,DD-SITE=datadoghq.com` |
-| `SERVICE_NAME` | Service name for metrics | `opendif-service` | `portal-backend` |
+| `SERVICE_NAME` | Service name for metrics | `openndx-service` | `portal-backend` |
 
 **Note:** For Docker Compose deployments, add these environment variables to your `docker-compose.yml`:
 
@@ -384,7 +384,7 @@ Prometheus periodically scrapes each service's `/metrics` endpoint:
 - **Interval**: Every 15 seconds (configurable in `prometheus.yml`)
 - **Method**: HTTP GET request to `http://<service>:<port>/metrics`
 - **Configuration**: Defined in `prometheus/prometheus.yml` as scrape jobs
-- **Network**: Uses Docker network (`opendif-network`) for service discovery
+- **Network**: Uses Docker network (`openndx-network`) for service discovery
 
 Example scrape config:
 ```yaml
@@ -449,17 +449,17 @@ Services automatically initialize OpenTelemetry metrics when first used. No expl
            port: 'PORT'
    ```
 
-4. **Ensure service is on `opendif-network`:**
+4. **Ensure service is on `openndx-network`:**
    In your service's `docker-compose.yml`:
    ```yaml
    services:
      your-service:
        networks:
-         - opendif-network
+         - openndx-network
    
    networks:
-     opendif-network:
-       name: opendif-network
+     openndx-network:
+       name: openndx-network
        external: true
    ```
 
@@ -507,7 +507,7 @@ Services automatically initialize OpenTelemetry metrics when first used. No expl
    ```
 
 3. Verify network connectivity:
-   - Ensure all services are on the same `opendif-network`
+   - Ensure all services are on the same `openndx-network`
    - Check service names match Prometheus configuration
 
 ### Grafana Can't Connect to Prometheus
@@ -518,7 +518,7 @@ Services automatically initialize OpenTelemetry metrics when first used. No expl
 
 1. Verify Prometheus is running: `curl http://localhost:9091/-/healthy`
 2. Check datasource URL in `grafana/provisioning/datasources/datasource.yml` (should be `http://prometheus:9090`)
-3. Ensure both containers are on the same Docker network (`opendif-network`)
+3. Ensure both containers are on the same Docker network (`openndx-network`)
 
 ### Network Issues
 
@@ -526,12 +526,12 @@ Services automatically initialize OpenTelemetry metrics when first used. No expl
 
 **Solutions:**
 
-1. Verify network exists: `docker network ls | grep opendif-network`
-2. Check service is on network: `docker network inspect opendif-network`
+1. Verify network exists: `docker network ls | grep openndx-network`
+2. Check service is on network: `docker network inspect openndx-network`
 3. Recreate network if needed:
    ```bash
    docker compose down
-   docker network rm opendif-network
+   docker network rm openndx-network
    docker compose up -d
    ```
 

--- a/observability/docker-compose.yml
+++ b/observability/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   prometheus:
     image: prom/prometheus:v2.55.1
-    container_name: opendif-prometheus
+    container_name: openndx-prometheus
     restart: unless-stopped
     ports:
       - "9091:9090"
@@ -16,11 +16,11 @@ services:
       - "--web.console.templates=/usr/share/prometheus/consoles"
       - "--web.enable-lifecycle"
     networks:
-      - opendif-network
+      - openndx-network
 
   grafana:
     image: grafana/grafana:11.2.0
-    container_name: opendif-grafana
+    container_name: openndx-grafana
     restart: unless-stopped
     ports:
       - "3002:3000"
@@ -34,7 +34,7 @@ services:
       - ./grafana/dashboards/:/var/lib/grafana/dashboards/
       - grafana-data:/var/lib/grafana
     networks:
-      - opendif-network
+      - openndx-network
     depends_on:
       - prometheus
 
@@ -43,7 +43,7 @@ volumes:
   grafana-data:
 
 networks:
-  opendif-network:
-    name: opendif-network
+  openndx-network:
+    name: openndx-network
     external: true
 

--- a/observability/grafana/dashboards/go-services-metrics.json
+++ b/observability/grafana/dashboards/go-services-metrics.json
@@ -181,7 +181,7 @@
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["go-services", "opendif"],
+  "tags": ["go-services", "openndx"],
   "templating": { "list": [] },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
   external_labels:
-    cluster: 'opendif-core'
+    cluster: 'openndx-core'
     environment: 'local'
 
 scrape_configs:

--- a/portal-backend/README.md
+++ b/portal-backend/README.md
@@ -97,9 +97,9 @@ CORS_ALLOWED_ORIGINS=*            # CORS allowed origins
 ### Authentication & Authorization
 
 **Supported Roles:**
-- `OpenDIF_Admin` - Full system access
-- `OpenDIF_Member` - Standard user access to own resources
-- `OpenDIF_System` - System-level read access
+- `OpenNDX_Admin` - Full system access
+- `OpenNDX_Member` - Standard user access to own resources
+- `OpenNDX_System` - System-level read access
 
 **JWT Requirements:**
 - Issuer: Asgardeo identity provider

--- a/portal-backend/openapi.yaml
+++ b/portal-backend/openapi.yaml
@@ -10,9 +10,9 @@ info:
     
     ## Authorization  
     The API implements role-based access control (RBAC) with the following roles:
-    - **OpenDIF_Admin**: Full system access and management capabilities
-    - **OpenDIF_Member**: Standard user access to own resources only
-    - **OpenDIF_System**: System-level operations with read access
+    - **OpenNDX_Admin**: Full system access and management capabilities
+    - **OpenNDX_Member**: Standard user access to own resources only
+    - **OpenNDX_System**: System-level operations with read access
     
     ## Features
     - JWT authentication with Asgardeo integration
@@ -25,7 +25,7 @@ info:
     with enterprise-grade security and performance optimizations.
   version: 1.0.0
   contact:
-    name: OpenDIF Team
+    name: OpenNDX Team
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/portal-backend/v1/middleware/audit_middleware_test.go
+++ b/portal-backend/v1/middleware/audit_middleware_test.go
@@ -226,7 +226,7 @@ func TestLogAudit_SendsRequest(t *testing.T) {
 	claims := &models.UserClaims{
 		IdpUserID: "test-user-id",
 		Email:     "test@example.com",
-		Roles:     models.FlexibleStringSlice([]string{"OpenDIF_Member"}),
+		Roles:     models.FlexibleStringSlice([]string{"OpenNDX_Member"}),
 		IssuedAt:  now,
 		ExpiresAt: now + 3600,
 	}

--- a/portal-backend/v1/middleware/jwt_auth_test.go
+++ b/portal-backend/v1/middleware/jwt_auth_test.go
@@ -153,7 +153,7 @@ func TestJWTAuthMiddleware_AuthenticateJWT(t *testing.T) {
 					"scope":     "read write",
 					"client_id": "client-1",
 					"username":  "testuser",
-					"roles":     []string{"OpenDIF_Member"},
+					"roles":     []string{"OpenNDX_Member"},
 				}
 				token := createToken(claims, privKey, kid)
 				req := httptest.NewRequest("GET", "/api/v1/resource", nil)

--- a/portal-backend/v1/models/authentication_performance_test.go
+++ b/portal-backend/v1/models/authentication_performance_test.go
@@ -12,7 +12,7 @@ func TestAuthenticatedUser_GetPermissions_Caching(t *testing.T) {
 		FirstName: "Admin",
 		LastName:  "User",
 		IdpUserID: "admin-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Admin"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Admin"},
 		Groups:    []string{"admins"},
 	}
 
@@ -60,7 +60,7 @@ func TestAuthenticatedUser_GetPermissions_Immutability(t *testing.T) {
 	claims := &UserClaims{
 		Email:     "member@example.com",
 		IdpUserID: "member-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Member"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Member"},
 	}
 
 	user, err := NewAuthenticatedUser(claims)
@@ -96,7 +96,7 @@ func TestAuthenticatedUser_MultipleRoles_PermissionMerging(t *testing.T) {
 	claims := &UserClaims{
 		Email:     "multirole@example.com",
 		IdpUserID: "multi-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Member", "OpenDIF_System"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Member", "OpenNDX_System"},
 	}
 
 	user, err := NewAuthenticatedUser(claims)
@@ -176,7 +176,7 @@ func BenchmarkGetPermissions_Cached(b *testing.B) {
 	claims := &UserClaims{
 		Email:     "admin@example.com",
 		IdpUserID: "admin-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Admin"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Admin"},
 	}
 
 	user, err := NewAuthenticatedUser(claims)
@@ -219,7 +219,7 @@ func BenchmarkUserCreation_WithPermissionCaching(b *testing.B) {
 	claims := &UserClaims{
 		Email:     "admin@example.com",
 		IdpUserID: "admin-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Admin"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Admin"},
 	}
 
 	b.ResetTimer()

--- a/portal-backend/v1/models/authentication_security_test.go
+++ b/portal-backend/v1/models/authentication_security_test.go
@@ -47,7 +47,7 @@ func TestNewAuthenticatedUser_ValidRoles(t *testing.T) {
 	claims := &UserClaims{
 		Email:     "validroles@example.com",
 		IdpUserID: "validroles-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Member"}, // Valid role
+		Roles:     FlexibleStringSlice{"OpenNDX_Member"}, // Valid role
 	}
 
 	user, err := NewAuthenticatedUser(claims)
@@ -73,7 +73,7 @@ func TestNewAuthenticatedUser_MixedRoles(t *testing.T) {
 	claims := &UserClaims{
 		Email:     "mixedroles@example.com",
 		IdpUserID: "mixedroles-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Admin", "InvalidRole", "OpenDIF_Member"}, // Mixed roles
+		Roles:     FlexibleStringSlice{"OpenNDX_Admin", "InvalidRole", "OpenNDX_Member"}, // Mixed roles
 	}
 
 	user, err := NewAuthenticatedUser(claims)

--- a/portal-backend/v1/models/authentication_thread_safety_test.go
+++ b/portal-backend/v1/models/authentication_thread_safety_test.go
@@ -13,7 +13,7 @@ func TestAuthenticatedUser_MemberIDCaching_ThreadSafety(t *testing.T) {
 	claims := &UserClaims{
 		Email:     "threadtest@example.com",
 		IdpUserID: "thread-test-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Member"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Member"},
 	}
 
 	user, err := NewAuthenticatedUser(claims)
@@ -85,7 +85,7 @@ func TestAuthenticatedUser_MemberIDCaching_BasicFunctionality(t *testing.T) {
 	claims := &UserClaims{
 		Email:     "cachetest@example.com",
 		IdpUserID: "cache-test-123",
-		Roles:     FlexibleStringSlice{"OpenDIF_Member"},
+		Roles:     FlexibleStringSlice{"OpenNDX_Member"},
 	}
 
 	user, err := NewAuthenticatedUser(claims)

--- a/portal-backend/v1/models/authorization.go
+++ b/portal-backend/v1/models/authorization.go
@@ -18,9 +18,9 @@ const (
 type Role string
 
 const (
-	RoleAdmin  Role = "OpenDIF_Admin"  // Full access to all resources
-	RoleMember Role = "OpenDIF_Member" // Access to own resources and public endpoints
-	RoleSystem Role = "OpenDIF_System" // System-level access for internal services
+	RoleAdmin  Role = "OpenNDX_Admin"  // Full access to all resources
+	RoleMember Role = "OpenNDX_Member" // Access to own resources and public endpoints
+	RoleSystem Role = "OpenNDX_System" // System-level access for internal services
 )
 
 // Permission represents specific permissions

--- a/portal-backend/v1/models/authorization_test.go
+++ b/portal-backend/v1/models/authorization_test.go
@@ -72,6 +72,6 @@ func TestRole_IsValid(t *testing.T) {
 }
 
 func TestRole_String(t *testing.T) {
-	assert.Equal(t, "OpenDIF_Admin", RoleAdmin.String())
-	assert.Equal(t, "OpenDIF_Member", RoleMember.String())
+	assert.Equal(t, "OpenNDX_Admin", RoleAdmin.String())
+	assert.Equal(t, "OpenNDX_Member", RoleMember.String())
 }

--- a/portal-backend/v1/models/constants.go
+++ b/portal-backend/v1/models/constants.go
@@ -4,8 +4,8 @@ package models
 type UserGroup string
 
 const (
-	UserGroupAdmin  UserGroup = "OpenDIF_Admin"
-	UserGroupMember UserGroup = "OpenDIF_Members"
+	UserGroupAdmin  UserGroup = "OpenNDX_Admin"
+	UserGroupMember UserGroup = "OpenNDX_Members"
 )
 
 // Status represents the status of submissions and applications

--- a/portal-backend/v1/services/member_service.go
+++ b/portal-backend/v1/services/member_service.go
@@ -24,7 +24,7 @@ func NewMemberService(db *gorm.DB, idp idp.IdentityProviderAPI) *MemberService {
 	return &MemberService{db: db, idp: idp}
 }
 
-// CreateMember creates a new Member and automatically adds them to the "OpenDIF_Members" group in the IDP.
+// CreateMember creates a new Member and automatically adds them to the "OpenNDX_Members" group in the IDP.
 // This ensures all newly created members are automatically assigned to the member group.
 func (s *MemberService) CreateMember(ctx context.Context, req *models.CreateMemberRequest) (*models.MemberResponse, error) {
 	// Create user in the IDP
@@ -47,7 +47,7 @@ func (s *MemberService) CreateMember(ctx context.Context, req *models.CreateMemb
 	}
 	slog.Info("Created user in IDP", "userID", createdUser.Id, "email", createdUser.Email)
 
-	// Automatically add user to "OpenDIF_Members" group in the IDP
+	// Automatically add user to "OpenNDX_Members" group in the IDP
 	// This is a core requirement: all new members must be assigned to the member group
 	groupMember := &idp.GroupMember{
 		Value:   createdUser.Id,

--- a/portals/README.md
+++ b/portals/README.md
@@ -1,6 +1,6 @@
 # Portals
 
-React-based portals for the OpenDIF platform.
+React-based portals for the OpenNDX platform.
 
 ## Portals
 

--- a/portals/admin-portal/README.md
+++ b/portals/admin-portal/README.md
@@ -1,11 +1,11 @@
 # Admin Portal
 
-A React-based administrative dashboard for OpenDIF administrators to manage members, schemas, and system configurations.
+A React-based administrative dashboard for OpenNDX administrators to manage members, schemas, and system configurations.
 
 ## Overview
 
 The Admin Portal provides a user interface for administrators to:
-- Manage OpenDIF members (onboard/offboard)
+- Manage OpenNDX members (onboard/offboard)
 - Review and approve schema submissions
 - Monitor system health and audit logs
 - Configure system-wide settings

--- a/portals/admin-portal/index.html
+++ b/portals/admin-portal/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenDIF</title>
+    <title>OpenNDX</title>
   </head>
   <body>
     <div id="root"></div>

--- a/portals/admin-portal/src/App.tsx
+++ b/portals/admin-portal/src/App.tsx
@@ -90,7 +90,7 @@ function App() {
           <Shield className="h-12 w-12 text-blue-500 mx-auto mb-4" />
           <h1 className="text-2xl font-bold text-gray-800 mb-4">Admin Portal</h1>
           <p className="text-gray-600 mb-4">
-            Sign in to access the OpenDIF Admin Portal.
+            Sign in to access the OpenNDX Admin Portal.
           </p>
           <button
             onClick={handleSignIn}

--- a/portals/consent-portal/README.md
+++ b/portals/consent-portal/README.md
@@ -4,7 +4,7 @@ A citizen-facing React application that allows data owners to view, approve, or 
 
 ## Overview
 
-The Consent Portal is the interface where citizens (data owners) interact with OpenDIF to manage their data consents. It is typically accessed via a redirect from a data consumer application when consent is required.
+The Consent Portal is the interface where citizens (data owners) interact with OpenNDX to manage their data consents. It is typically accessed via a redirect from a data consumer application when consent is required.
 
 **Technology**: React + TypeScript + TailwindCSS + Vite
 

--- a/portals/consent-portal/index.html
+++ b/portals/consent-portal/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenDIF</title>
+    <title>OpenNDX</title>
   </head>
   <body>
     <div id="root"></div>

--- a/portals/member-portal/README.md
+++ b/portals/member-portal/README.md
@@ -1,6 +1,6 @@
 # Member Portal
 
-A React-based dashboard for OpenDIF members to manage their data schemas, applications, and integration settings.
+A React-based dashboard for OpenNDX members to manage their data schemas, applications, and integration settings.
 
 ## Overview
 

--- a/portals/member-portal/index.html
+++ b/portals/member-portal/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenDIF</title>
+    <title>OpenNDX</title>
   </head>
   <body>
     <div id="root"></div>

--- a/portals/member-portal/src/App.tsx
+++ b/portals/member-portal/src/App.tsx
@@ -168,7 +168,7 @@ function App() {
           <Shield className="h-12 w-12 text-blue-500 mx-auto mb-4" />
           <h1 className="text-2xl font-bold text-gray-800 mb-4">Member Portal</h1>
           <p className="text-gray-600 mb-4">
-            Sign in to access the OpenDIF Member Portal.
+            Sign in to access the OpenNDX Member Portal.
           </p>
           <button
             onClick={handleSignIn}

--- a/scripts/test-docker-builds.sh
+++ b/scripts/test-docker-builds.sh
@@ -45,7 +45,7 @@ build_service() {
         --build-arg BUILD_VERSION="$BUILD_VERSION" \
         --build-arg BUILD_TIME="$BUILD_TIME" \
         --build-arg GIT_COMMIT="$GIT_COMMIT" \
-        --tag "opendif-core/$service_name:test" \
+        --tag "openndx-core/$service_name:test" \
         . ; then
         echo -e "${GREEN}✓ $service_name build succeeded${NC}"
         PASSED_SERVICES+=("$service_name")


### PR DESCRIPTION
## What

Finishes the OpenNDX rebrand of all **remaining** legacy references (human-facing text + identifiers), the follow-up to the Go module-path migration (#474, #475). Two commits:

1. **`OpenDIF`/`opendif`** (and the old `opendif-mvp` repo slug) → `OpenNDX`/`openndx-core` across docs, READMEs, workflows, `Makefile`, git hooks, Dockerfile comments, `docker-compose`/observability config, OpenAPI specs, portal UIs, and code comments/strings.
2. **`Gov DX Sandbox`** → `OpenNDX`: PDP OpenAPI contact (`Gov DX Sandbox Team`/`support@gov-dx-sandbox.com` → `OpenNDX Team`/`support@openndx.dev`, matching the other specs), plus two stale `observability/README.md` doc import examples still on `github.com/gov-dx-sandbox/...` → `github.com/OpenNDX/openndx-core/...`.

After this, `git grep -i opendif` and `git grep -i gov-dx-sandbox` both return **zero** matches.

## Rename-only

Pure 1:1 token swap — **134 insertions, 134 deletions**, every changed line is a rename. No formatting, no content, no dependency changes. Token mapping:

- `opendif-mvp` → `openndx-core` (old repo slug in GitHub URLs / clone instructions)
- `OpenDIF` → `OpenNDX`
- `opendif` → `openndx`

No `go.mod`/`replace`/Dockerfile-context changes — builds stay proxy-based, and the coupling reverted in #473 is not reintroduced.

## ⚠️ BREAKING CHANGE — coordinate these with external systems

Two of the renamed tokens are runtime-coupled identifiers, not just display text:

**1. Authorization role/group values (`portal-backend`)**
- `OpenDIF_Admin` / `OpenDIF_Member` / `OpenDIF_System` → `OpenNDX_*`
- IDP group `OpenDIF_Members` → `OpenNDX_Members`

These are matched against the identity provider's group/role names and JWT role claims. **The IDP's groups/roles must be renamed to match**, or existing users lose authorization and newly created members are added to a non-existent group.

**2. OpenTelemetry metric attribute keys + meter/service name (`exchange/shared/monitoring`)**
- `opendif.business.action` / `.business.outcome` / `.external.target` / `.external.operation` → `openndx.*`
- meter `"opendif"` → `"openndx"`; default service name `"opendif-service"` → `"openndx-service"`

**External** Prometheus queries, alerts, and Grafana panels referencing the old keys must be updated. (The in-repo Grafana dashboard does not reference these attribute keys.)

## Verification

- Pre-commit hook passed for all affected services: `consent-engine`, `orchestration-engine`, `policy-decision-point`, `portal-backend` (Go build + vet + tests) and `member-portal`, `admin-portal`, `consent-portal` (lint + build).
- `git grep -i opendif` and `git grep -i gov-dx-sandbox` → **no matches** remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
