### PR TITLE
Consent Engine: single configurable UID claim, drop owner_email (#477)

### DIFF
--- a/exchange/consent-engine/.env.example
+++ b/exchange/consent-engine/.env.example
@@ -27,7 +27,8 @@ RUN_MIGRATION=false
 # IDP Configuration
 # =============================================================================
 # The verifier validates issuer, audience, and client_id when each is set,
-# extracts the email claim, and is otherwise IdP-agnostic (no organization claim).
+# extracts the owner UID from the token's "sub" claim, and is otherwise
+# IdP-agnostic (no organization claim).
 IDP_ISSUER=
 IDP_AUDIENCE=
 IDP_CLIENT_ID=

--- a/exchange/consent-engine/.env.example
+++ b/exchange/consent-engine/.env.example
@@ -27,12 +27,15 @@ RUN_MIGRATION=false
 # IDP Configuration
 # =============================================================================
 # The verifier validates issuer, audience, and client_id when each is set,
-# extracts the owner UID from the token's "sub" claim, and is otherwise
+# extracts the owner UID from the configured subject claim, and is otherwise
 # IdP-agnostic (no organization claim).
 IDP_ISSUER=
 IDP_AUDIENCE=
 IDP_CLIENT_ID=
 IDP_JWKS_URL=
+# Token claim carrying the data owner's canonical UID (matched against the
+# consent record's owner_id). Defaults to the standard OIDC "sub".
+IDP_SUBJECT_CLAIM=sub
 # Dev-only: skip TLS verification on the JWKS fetch (e.g. a self-signed local
 # IdP). Leave false in production.
 IDP_JWKS_INSECURE_SKIP_VERIFY=false

--- a/exchange/consent-engine/README.md
+++ b/exchange/consent-engine/README.md
@@ -18,21 +18,22 @@ Service runs on port **8081** by default.
 
 ### Environment Variables
 
-| Variable             | Description             | Default                 |
-|----------------------|-------------------------|-------------------------|
-| `PORT`               | Service port            | `8081`                  |
-| `ENVIRONMENT`        | `production` or `local` | `local`                 |
-| `CONSENT_PORTAL_URL` | Consent Portal URL      | `http://localhost:5173` |
-| `IDP_ORG_NAME`       | IDP organization name   | -                       |
-| `IDP_ISSUER`         | JWT issuer URL          | -                       |
-| `IDP_AUDIENCE`       | JWT audience            | -                       |
-| `IDP_JWKS_URL`       | JWKS endpoint URL       | -                       |
-| `DB_HOST`            | Database host           | `localhost`             |
-| `DB_PORT`            | Database port           | `5432`                  |
-| `DB_USERNAME`        | Database username       | `postgres`              |
-| `DB_PASSWORD`        | Database password       | -                       |
-| `DB_NAME`            | Database name           | `consent_engine`        |
-| `DB_SSLMODE`         | SSL mode                | `require`               |
+| Variable             | Description                                                             | Default                 |
+|----------------------|-------------------------------------------------------------------------|-------------------------|
+| `PORT`               | Service port                                                            | `8081`                  |
+| `ENVIRONMENT`        | `production` or `local`                                                 | `local`                 |
+| `CONSENT_PORTAL_URL` | Consent Portal URL                                                      | `http://localhost:5173` |
+| `IDP_ORG_NAME`       | IDP organization name                                                   | -                       |
+| `IDP_ISSUER`         | JWT issuer URL                                                          | -                       |
+| `IDP_AUDIENCE`       | JWT audience                                                            | -                       |
+| `IDP_JWKS_URL`       | JWKS endpoint URL                                                       | -                       |
+| `IDP_SUBJECT_CLAIM`  | Token claim carrying the owner UID (matched against consent `owner_id`) | `sub`                   |
+| `DB_HOST`            | Database host                                                           | `localhost`             |
+| `DB_PORT`            | Database port                                                           | `5432`                  |
+| `DB_USERNAME`        | Database username                                                       | `postgres`              |
+| `DB_PASSWORD`        | Database password                                                       | -                       |
+| `DB_NAME`            | Database name                                                           | `consent_engine`        |
+| `DB_SSLMODE`         | SSL mode                                                                | `require`               |
 
 ## API Endpoints
 

--- a/exchange/consent-engine/internal/config/config.go
+++ b/exchange/consent-engine/internal/config/config.go
@@ -47,6 +47,9 @@ type IDPConfig struct {
 	JwksUrl  string
 	Audience string
 	ClientID string
+	// SubjectClaim is the token claim carrying the data owner's canonical UID
+	// (matched against the consent record's owner_id). Defaults to "sub".
+	SubjectClaim string
 	// InsecureSkipVerify skips TLS verification on the JWKS fetch. Dev-only
 	// (e.g. a self-signed local IdP); leave false in production.
 	InsecureSkipVerify bool
@@ -86,6 +89,8 @@ func LoadConfig(serviceName string) *Config {
 	userAudience := utils.GetEnvOrDefault("IDP_AUDIENCE", "")
 	userJwksURL := utils.GetEnvOrDefault("IDP_JWKS_URL", "")
 	userClientID := utils.GetEnvOrDefault("IDP_CLIENT_ID", "")
+	// Token claim carrying the owner UID matched against consent owner_id.
+	userSubjectClaim := utils.GetEnvOrDefault("IDP_SUBJECT_CLAIM", "sub")
 	// Dev-only: skip TLS verification on the JWKS fetch (self-signed local IdP).
 	jwksInsecureSkipVerify, _ := strconv.ParseBool(utils.GetEnvOrDefault("IDP_JWKS_INSECURE_SKIP_VERIFY", "false"))
 
@@ -130,6 +135,7 @@ func LoadConfig(serviceName string) *Config {
 			JwksUrl:            userJwksURL,
 			Audience:           userAudience,
 			ClientID:           userClientID,
+			SubjectClaim:       userSubjectClaim,
 			InsecureSkipVerify: jwksInsecureSkipVerify,
 		},
 		DBConfigs: DBConfigs{

--- a/exchange/consent-engine/main.go
+++ b/exchange/consent-engine/main.go
@@ -82,6 +82,7 @@ func main() {
 		"issuer", cfg.IDPConfig.Issuer,
 		"audience", cfg.IDPConfig.Audience,
 		"jwks_url", cfg.IDPConfig.JwksUrl,
+		"subject_claim", cfg.IDPConfig.SubjectClaim,
 		"jwks_insecure_skip_verify", cfg.IDPConfig.InsecureSkipVerify)
 
 	v1JWTVerifier, err := v1auth.NewJWTVerifier(v1auth.JWTVerifierConfig{
@@ -89,6 +90,7 @@ func main() {
 		Issuer:             cfg.IDPConfig.Issuer,
 		Audience:           cfg.IDPConfig.Audience,
 		ClientID:           cfg.IDPConfig.ClientID,
+		SubjectClaim:       cfg.IDPConfig.SubjectClaim,
 		InsecureSkipVerify: cfg.IDPConfig.InsecureSkipVerify,
 	})
 	if err != nil {

--- a/exchange/consent-engine/v1/auth/jwt_verifier.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier.go
@@ -268,8 +268,10 @@ func (jv *JWTVerifier) VerifyToken(tokenString string) (*jwt.Token, error) {
 	return token, nil
 }
 
-// VerifyTokenAndExtractEmail verifies the token and extracts the email claim
-func (jv *JWTVerifier) VerifyTokenAndExtractEmail(tokenString string) (string, error) {
+// VerifyTokenAndExtractSubject verifies the token and extracts the subject claim
+// that identifies the data owner (their canonical UID). The claim is the standard
+// OIDC "sub"; a later change makes which claim carries the UID configurable.
+func (jv *JWTVerifier) VerifyTokenAndExtractSubject(tokenString string) (string, error) {
 	token, err := jv.VerifyToken(tokenString)
 	if err != nil {
 		return "", err
@@ -280,10 +282,10 @@ func (jv *JWTVerifier) VerifyTokenAndExtractEmail(tokenString string) (string, e
 		return "", fmt.Errorf("invalid token claims")
 	}
 
-	email, ok := claims["email"].(string)
-	if !ok || email == "" {
-		return "", fmt.Errorf("email claim not found or empty in token")
+	subject, ok := claims["sub"].(string)
+	if !ok || subject == "" {
+		return "", fmt.Errorf("sub claim not found or empty in token")
 	}
 
-	return email, nil
+	return subject, nil
 }

--- a/exchange/consent-engine/v1/auth/jwt_verifier.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier.go
@@ -39,11 +39,20 @@ type JWTVerifierConfig struct {
 	Issuer   string
 	Audience string
 	ClientID string
+	// SubjectClaim is the token claim whose value is the data owner's canonical
+	// UID (matched against the consent record's owner_id). It lets each identity
+	// provider declare which claim carries the UID (e.g. "sub", "email",
+	// "individual_id"). When empty it defaults to the standard OIDC "sub".
+	SubjectClaim string
 	// InsecureSkipVerify disables TLS certificate verification for the JWKS
 	// fetch. Intended only for local/dev IdPs using self-signed certs; leave
 	// false in production.
 	InsecureSkipVerify bool
 }
+
+// DefaultSubjectClaim is the token claim used to identify the data owner when
+// no SubjectClaim is configured.
+const DefaultSubjectClaim = "sub"
 
 // JWTVerifier handles JWT token verification
 type JWTVerifier struct {
@@ -268,9 +277,10 @@ func (jv *JWTVerifier) VerifyToken(tokenString string) (*jwt.Token, error) {
 	return token, nil
 }
 
-// VerifyTokenAndExtractSubject verifies the token and extracts the subject claim
-// that identifies the data owner (their canonical UID). The claim is the standard
-// OIDC "sub"; a later change makes which claim carries the UID configurable.
+// VerifyTokenAndExtractSubject verifies the token and extracts the data owner's
+// canonical UID from the configured SubjectClaim (defaulting to the standard
+// OIDC "sub"). This is the identifier matched against the consent record's
+// owner_id during portal authorization.
 func (jv *JWTVerifier) VerifyTokenAndExtractSubject(tokenString string) (string, error) {
 	token, err := jv.VerifyToken(tokenString)
 	if err != nil {
@@ -282,9 +292,14 @@ func (jv *JWTVerifier) VerifyTokenAndExtractSubject(tokenString string) (string,
 		return "", fmt.Errorf("invalid token claims")
 	}
 
-	subject, ok := claims["sub"].(string)
+	claimName := jv.config.SubjectClaim
+	if claimName == "" {
+		claimName = DefaultSubjectClaim
+	}
+
+	subject, ok := claims[claimName].(string)
 	if !ok || subject == "" {
-		return "", fmt.Errorf("sub claim not found or empty in token")
+		return "", fmt.Errorf("subject claim %q not found or empty in token", claimName)
 	}
 
 	return subject, nil

--- a/exchange/consent-engine/v1/auth/jwt_verifier_test.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier_test.go
@@ -176,6 +176,31 @@ func TestVerifyTokenAndExtractSubject_MissingSubjectFails(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestVerifyTokenAndExtractSubject_DefaultsToSubWhenUnconfigured(t *testing.T) {
+	// fullConfig leaves SubjectClaim empty, so it falls back to "sub".
+	v, priv := newTestVerifier(t, fullConfig())
+	subject, err := v.VerifyTokenAndExtractSubject(signToken(t, priv, baseClaims()))
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", subject)
+}
+
+func TestVerifyTokenAndExtractSubject_UsesConfiguredClaim(t *testing.T) {
+	cfg := fullConfig()
+	cfg.SubjectClaim = "email" // point the UID at a different claim
+	v, priv := newTestVerifier(t, cfg)
+	subject, err := v.VerifyTokenAndExtractSubject(signToken(t, priv, baseClaims()))
+	require.NoError(t, err)
+	assert.Equal(t, "nayana@opensource.lk", subject)
+}
+
+func TestVerifyTokenAndExtractSubject_ConfiguredClaimMissingFails(t *testing.T) {
+	cfg := fullConfig()
+	cfg.SubjectClaim = "individual_id" // claim not present in the token
+	v, priv := newTestVerifier(t, cfg)
+	_, err := v.VerifyTokenAndExtractSubject(signToken(t, priv, baseClaims()))
+	assert.Error(t, err)
+}
+
 // newTLSTestVerifier serves the JWKS over a self-signed HTTPS server (like a
 // dev IdP), so JWKS fetches fail TLS verification unless InsecureSkipVerify is set.
 func newTLSTestVerifier(t *testing.T, cfg JWTVerifierConfig) (*JWTVerifier, *rsa.PrivateKey) {

--- a/exchange/consent-engine/v1/auth/jwt_verifier_test.go
+++ b/exchange/consent-engine/v1/auth/jwt_verifier_test.go
@@ -83,9 +83,9 @@ func fullConfig() JWTVerifierConfig {
 
 func TestVerifyToken_ThunderIDShapedTokenPasses(t *testing.T) {
 	v, priv := newTestVerifier(t, fullConfig())
-	email, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, baseClaims()))
+	subject, err := v.VerifyTokenAndExtractSubject(signToken(t, priv, baseClaims()))
 	require.NoError(t, err)
-	assert.Equal(t, "nayana@opensource.lk", email)
+	assert.Equal(t, "user-123", subject)
 }
 
 func TestVerifyToken_AudienceAsArrayPasses(t *testing.T) {
@@ -168,11 +168,11 @@ func TestVerifyToken_NonRSAMethodFails(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestVerifyTokenAndExtractEmail_MissingEmailFails(t *testing.T) {
+func TestVerifyTokenAndExtractSubject_MissingSubjectFails(t *testing.T) {
 	v, priv := newTestVerifier(t, fullConfig())
 	claims := baseClaims()
-	delete(claims, "email")
-	_, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, claims))
+	delete(claims, "sub")
+	_, err := v.VerifyTokenAndExtractSubject(signToken(t, priv, claims))
 	assert.Error(t, err)
 }
 
@@ -216,7 +216,7 @@ func TestVerifyToken_SelfSignedJWKSPassesWithSkipVerify(t *testing.T) {
 	cfg := fullConfig()
 	cfg.InsecureSkipVerify = true
 	v, priv := newTLSTestVerifier(t, cfg)
-	email, err := v.VerifyTokenAndExtractEmail(signToken(t, priv, baseClaims()))
+	subject, err := v.VerifyTokenAndExtractSubject(signToken(t, priv, baseClaims()))
 	require.NoError(t, err)
-	assert.Equal(t, "nayana@opensource.lk", email)
+	assert.Equal(t, "user-123", subject)
 }

--- a/exchange/consent-engine/v1/handlers/internal_handler.go
+++ b/exchange/consent-engine/v1/handlers/internal_handler.go
@@ -38,7 +38,7 @@ func (h *InternalHandler) HealthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetConsent handles GET /internal/api/v1/consents
-// Query parameters: ownerEmail & appId OR ownerId & appId
+// Query parameters: ownerId & appId
 // Returns: models.ConsentResponseInternalView
 func (h *InternalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
@@ -47,7 +47,6 @@ func (h *InternalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse query parameters
-	ownerEmail := r.URL.Query().Get("ownerEmail")
 	ownerID := r.URL.Query().Get("ownerId")
 	appID := r.URL.Query().Get("appId")
 
@@ -57,20 +56,13 @@ func (h *InternalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ownerEmail == "" && ownerID == "" {
-		utils.RespondWithError(w, http.StatusBadRequest, models.ErrorCodeBadRequest, "either ownerEmail or ownerId is required")
+	if ownerID == "" {
+		utils.RespondWithError(w, http.StatusBadRequest, models.ErrorCodeBadRequest, "ownerId is required")
 		return
 	}
 
 	// Get consent from service (context with timeout is propagated)
-	var consent *models.ConsentResponseInternalView
-	var err error
-
-	if ownerEmail != "" {
-		consent, err = h.consentService.GetConsentInternalView(r.Context(), nil, nil, &ownerEmail, &appID)
-	} else {
-		consent, err = h.consentService.GetConsentInternalView(r.Context(), nil, &ownerID, nil, &appID)
-	}
+	consent, err := h.consentService.GetConsentInternalView(r.Context(), nil, &ownerID, &appID)
 
 	if err != nil {
 		// Check if error is due to context cancellation or timeout

--- a/exchange/consent-engine/v1/handlers/portal_handler.go
+++ b/exchange/consent-engine/v1/handlers/portal_handler.go
@@ -41,7 +41,7 @@ func (h *PortalHandler) HealthCheck(w http.ResponseWriter, r *http.Request) {
 
 // GetConsent handles GET /api/v1/consents/:consentId
 // Authorization: Bearer Token
-// Verifies that consent.owner_email matches the email from the decoded token
+// Verifies that consent.owner_id matches the subject (UID) from the decoded token
 func (h *PortalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		utils.RespondWithError(w, http.StatusMethodNotAllowed, models.ErrorCodeMethodNotAllowed, "Method not allowed")
@@ -61,10 +61,10 @@ func (h *PortalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract email from request context (set by auth middleware)
-	userEmail, ok := middleware.GetUserEmailFromContext(r.Context())
+	// Extract owner subject (UID) from request context (set by auth middleware)
+	ownerSubject, ok := middleware.GetOwnerSubjectFromContext(r.Context())
 	if !ok {
-		utils.RespondWithError(w, http.StatusUnauthorized, models.ErrorCodeUnauthorized, "User email not found in token")
+		utils.RespondWithError(w, http.StatusUnauthorized, models.ErrorCodeUnauthorized, "Owner identifier not found in token")
 		return
 	}
 
@@ -86,8 +86,8 @@ func (h *PortalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify that the consent owner email matches the authenticated user email
-	if consent.OwnerEmail != userEmail {
+	// Verify that the consent owner matches the authenticated user's subject (UID)
+	if consent.OwnerID != ownerSubject {
 		utils.RespondWithError(w, http.StatusForbidden, models.ErrorCodeForbidden, "Access denied: consent belongs to a different user")
 		return
 	}
@@ -97,7 +97,7 @@ func (h *PortalHandler) GetConsent(w http.ResponseWriter, r *http.Request) {
 
 // UpdateConsent handles PUT /api/v1/consents/:consentId
 // Authorization: Bearer Token
-// Verifies that consent.owner_email matches the email from the decoded token
+// Verifies that consent.owner_id matches the subject (UID) from the decoded token
 // Body: { "action": "approve" | "reject" }
 func (h *PortalHandler) UpdateConsent(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
@@ -118,10 +118,10 @@ func (h *PortalHandler) UpdateConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract email from request context (set by auth middleware)
-	userEmail, ok := middleware.GetUserEmailFromContext(r.Context())
+	// Extract owner subject (UID) from request context (set by auth middleware)
+	ownerSubject, ok := middleware.GetOwnerSubjectFromContext(r.Context())
 	if !ok {
-		utils.RespondWithError(w, http.StatusUnauthorized, models.ErrorCodeUnauthorized, "User email not found in token")
+		utils.RespondWithError(w, http.StatusUnauthorized, models.ErrorCodeUnauthorized, "Owner identifier not found in token")
 		return
 	}
 
@@ -159,8 +159,8 @@ func (h *PortalHandler) UpdateConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify that the consent owner email matches the authenticated user email
-	if consent.OwnerEmail != userEmail {
+	// Verify that the consent owner matches the authenticated user's subject (UID)
+	if consent.OwnerID != ownerSubject {
 		utils.RespondWithError(w, http.StatusForbidden, models.ErrorCodeForbidden, "Access denied: consent belongs to a different user")
 		return
 	}
@@ -169,7 +169,7 @@ func (h *PortalHandler) UpdateConsent(w http.ResponseWriter, r *http.Request) {
 	updateReq := models.ConsentPortalActionRequest{
 		ConsentID: consentID,
 		Action:    models.ConsentPortalAction(actionReq.Action),
-		UpdatedBy: userEmail,
+		UpdatedBy: ownerSubject,
 	}
 
 	if err := h.consentService.UpdateConsentStatusByPortalAction(r.Context(), updateReq); err != nil {

--- a/exchange/consent-engine/v1/handlers/portal_handler_test.go
+++ b/exchange/consent-engine/v1/handlers/portal_handler_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// setUserEmailInContext is a test helper to set user email in context
-// Uses the same context key as middleware.auth.go (userEmailKey = "userEmail")
-func setUserEmailInContext(ctx context.Context, email string) context.Context {
+// setOwnerSubjectInContext is a test helper to set the owner subject (UID) in context
+// Uses the same context key as middleware.auth.go (ownerSubjectKey = "ownerSubject")
+func setOwnerSubjectInContext(ctx context.Context, subject string) context.Context {
 	type contextKey string
-	const userEmailKey contextKey = "userEmail"
-	return context.WithValue(ctx, userEmailKey, email)
+	const ownerSubjectKey contextKey = "ownerSubject"
+	return context.WithValue(ctx, ownerSubjectKey, subject)
 }
 
 func TestPortalHandler_HealthCheck(t *testing.T) {
@@ -61,7 +61,7 @@ func TestPortalHandler_GetConsent_InvalidUUID(t *testing.T) {
 	handler := &PortalHandler{consentService: nil}
 
 	req := httptest.NewRequest("GET", "/api/v1/consents/invalid-uuid", nil)
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	handler.GetConsent(w, req)
@@ -73,7 +73,7 @@ func TestPortalHandler_UpdateConsent_InvalidUUID(t *testing.T) {
 	handler := &PortalHandler{consentService: nil}
 
 	req := httptest.NewRequest("PUT", "/api/v1/consents/invalid-uuid", nil)
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	handler.UpdateConsent(w, req)
@@ -89,7 +89,7 @@ func TestPortalHandler_UpdateConsent_InvalidAction(t *testing.T) {
 	body, _ := json.Marshal(reqBody)
 	req := httptest.NewRequest("PUT", "/api/v1/consents/"+consentID, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	handler.UpdateConsent(w, req)
@@ -102,7 +102,7 @@ func TestPortalHandler_UpdateConsent_MethodNotAllowed(t *testing.T) {
 
 	consentID := uuid.New().String()
 	req := httptest.NewRequest("GET", "/api/v1/consents/"+consentID, nil)
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	handler.UpdateConsent(w, req)
@@ -121,7 +121,7 @@ func TestPortalHandler_UpdateConsent_RejectAction(t *testing.T) {
 	body, _ := json.Marshal(reqBody)
 	req := httptest.NewRequest("PUT", "/api/v1/consents/"+consentID, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	// PathValue requires registered route, so this tests validation up to that point
@@ -137,7 +137,7 @@ func TestPortalHandler_UpdateConsent_InvalidBody(t *testing.T) {
 	consentID := uuid.New().String()
 	req := httptest.NewRequest("PUT", "/api/v1/consents/"+consentID, bytes.NewBufferString("invalid json"))
 	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	handler.UpdateConsent(w, req)
@@ -149,7 +149,7 @@ func TestPortalHandler_UpdateConsent_MissingConsentId(t *testing.T) {
 	handler := &PortalHandler{consentService: nil}
 
 	req := httptest.NewRequest("PUT", "/api/v1/consents/", nil)
-	req = req.WithContext(setUserEmailInContext(req.Context(), "user@example.com"))
+	req = req.WithContext(setOwnerSubjectInContext(req.Context(), "user-123"))
 	w := httptest.NewRecorder()
 
 	handler.UpdateConsent(w, req)

--- a/exchange/consent-engine/v1/middleware/auth.go
+++ b/exchange/consent-engine/v1/middleware/auth.go
@@ -16,8 +16,8 @@ import (
 type contextKey string
 
 const (
-	// userEmailKey is the context key for user email
-	userEmailKey contextKey = "userEmail"
+	// ownerSubjectKey is the context key for the authenticated owner's subject (UID)
+	ownerSubjectKey contextKey = "ownerSubject"
 )
 
 // JWTAuthMiddleware provides HTTP middleware for JWT authentication
@@ -56,27 +56,27 @@ func (m *JWTAuthMiddleware) Authenticate(next http.Handler) http.Handler {
 			return
 		}
 
-		// Verify token and extract email
-		email, err := m.verifier.VerifyTokenAndExtractEmail(tokenString)
+		// Verify token and extract the owner subject (UID)
+		subject, err := m.verifier.VerifyTokenAndExtractSubject(tokenString)
 		if err != nil {
 			slog.Warn("Token verification failed", "error", err)
 			utils.RespondWithError(w, http.StatusUnauthorized, models.ErrorCodeUnauthorized, "Invalid or expired token")
 			return
 		}
 
-		// Add email to request context
-		ctx := context.WithValue(r.Context(), userEmailKey, email)
+		// Add owner subject to request context
+		ctx := context.WithValue(r.Context(), ownerSubjectKey, subject)
 		r = r.WithContext(ctx)
 
-		slog.Debug("User authenticated", "email", email)
+		slog.Debug("User authenticated", "subject", subject)
 
 		// Call next handler
 		next.ServeHTTP(w, r)
 	})
 }
 
-// GetUserEmailFromContext extracts the user email from the request context
-func GetUserEmailFromContext(ctx context.Context) (string, bool) {
-	email, ok := ctx.Value(userEmailKey).(string)
-	return email, ok
+// GetOwnerSubjectFromContext extracts the authenticated owner's subject (UID) from the request context
+func GetOwnerSubjectFromContext(ctx context.Context) (string, bool) {
+	subject, ok := ctx.Value(ownerSubjectKey).(string)
+	return subject, ok
 }

--- a/exchange/consent-engine/v1/middleware/auth_test.go
+++ b/exchange/consent-engine/v1/middleware/auth_test.go
@@ -94,11 +94,11 @@ func createTestJWTVerifier(t *testing.T, privateKey *rsa.PrivateKey, issuer, aud
 	return verifier
 }
 
-func createTestToken(t *testing.T, privateKey *rsa.PrivateKey, issuer, audience, email string) string {
+func createTestToken(t *testing.T, privateKey *rsa.PrivateKey, issuer, audience, subject string) string {
 	claims := jwt.MapClaims{
 		"iss":      issuer,
 		"aud":      audience,
-		"email":    email,
+		"sub":      subject,
 		"org_name": "test-org",
 		"exp":      time.Now().Add(time.Hour).Unix(),
 		"iat":      time.Now().Unix(),
@@ -131,7 +131,7 @@ func TestJWTAuthMiddleware_Authenticate_Success(t *testing.T) {
 	verifier := createTestJWTVerifier(t, privateKey, "test-issuer", "test-audience")
 	middleware := NewJWTAuthMiddleware(verifier)
 
-	token := createTestToken(t, privateKey, "test-issuer", "test-audience", "user@example.com")
+	token := createTestToken(t, privateKey, "test-issuer", "test-audience", "user-123")
 
 	req := httptest.NewRequest("GET", "/api/v1/consents/123", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -140,9 +140,9 @@ func TestJWTAuthMiddleware_Authenticate_Success(t *testing.T) {
 	nextCalled := false
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
-		email, ok := GetUserEmailFromContext(r.Context())
+		subject, ok := GetOwnerSubjectFromContext(r.Context())
 		assert.True(t, ok)
-		assert.Equal(t, "user@example.com", email)
+		assert.Equal(t, "user-123", subject)
 	})
 
 	middleware.Authenticate(next).ServeHTTP(w, req)
@@ -238,26 +238,26 @@ func TestJWTAuthMiddleware_Authenticate_InvalidToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
-func TestGetUserEmailFromContext(t *testing.T) {
-	ctx := context.WithValue(context.Background(), userEmailKey, "user@example.com")
+func TestGetOwnerSubjectFromContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ownerSubjectKey, "user-123")
 
-	email, ok := GetUserEmailFromContext(ctx)
+	subject, ok := GetOwnerSubjectFromContext(ctx)
 	assert.True(t, ok)
-	assert.Equal(t, "user@example.com", email)
+	assert.Equal(t, "user-123", subject)
 }
 
-func TestGetUserEmailFromContext_NotFound(t *testing.T) {
+func TestGetOwnerSubjectFromContext_NotFound(t *testing.T) {
 	ctx := context.Background()
 
-	email, ok := GetUserEmailFromContext(ctx)
+	subject, ok := GetOwnerSubjectFromContext(ctx)
 	assert.False(t, ok)
-	assert.Empty(t, email)
+	assert.Empty(t, subject)
 }
 
-func TestGetUserEmailFromContext_WrongType(t *testing.T) {
-	ctx := context.WithValue(context.Background(), userEmailKey, 123)
+func TestGetOwnerSubjectFromContext_WrongType(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ownerSubjectKey, 123)
 
-	email, ok := GetUserEmailFromContext(ctx)
+	subject, ok := GetOwnerSubjectFromContext(ctx)
 	assert.False(t, ok)
-	assert.Empty(t, email)
+	assert.Empty(t, subject)
 }

--- a/exchange/consent-engine/v1/migrations/add_consent_unique_tuple_constraint.sql
+++ b/exchange/consent-engine/v1/migrations/add_consent_unique_tuple_constraint.sql
@@ -27,9 +27,10 @@ CREATE TABLE IF NOT EXISTS consent_records (
 );
 
 -- Create partial unique index for active consents (pending or approved)
--- This enforces that only one active consent can exist per (owner_id, app_id)
+-- status is intentionally kept only in the WHERE filter (not the key columns),
+-- so at most one active consent (pending OR approved) can exist per (owner_id, app_id).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique
-    ON consent_records(owner_id, app_id, status)
+    ON consent_records(owner_id, app_id)
     WHERE status IN ('pending', 'approved');
 
 -- Create indexes for better query performance

--- a/exchange/consent-engine/v1/migrations/add_consent_unique_tuple_constraint.sql
+++ b/exchange/consent-engine/v1/migrations/add_consent_unique_tuple_constraint.sql
@@ -1,16 +1,16 @@
 -- Migration: Create consent_records table with partial unique constraint for active consents
 -- Date: 2025-12-12
 -- Description: Creates the consent_records table with consent_id as primary key
---              and a partial unique index on (owner_id, owner_email, app_id, status)
+--              and a partial unique index on (owner_id, app_id, status)
 --              that only applies when status is 'pending' or 'approved'.
---              This ensures only one active consent exists per (owner_id, owner_email, app_id),
+--              This ensures only one active consent exists per (owner_id, app_id),
 --              while allowing multiple historical records (rejected, expired, revoked).
+--              A user is identified system-wide by the single canonical owner_id (UID).
 
 -- Create the consent_records table if it doesn't exist
 CREATE TABLE IF NOT EXISTS consent_records (
     consent_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     owner_id VARCHAR(255) NOT NULL,
-    owner_email VARCHAR(255) NOT NULL,
     app_id VARCHAR(255) NOT NULL,
     app_name VARCHAR(255),
     status VARCHAR(50) NOT NULL,
@@ -27,14 +27,13 @@ CREATE TABLE IF NOT EXISTS consent_records (
 );
 
 -- Create partial unique index for active consents (pending or approved)
--- This enforces that only one active consent can exist per (owner_id, owner_email, app_id)
-CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique 
-    ON consent_records(owner_id, owner_email, app_id, status)
+-- This enforces that only one active consent can exist per (owner_id, app_id)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique
+    ON consent_records(owner_id, app_id, status)
     WHERE status IN ('pending', 'approved');
 
 -- Create indexes for better query performance
 CREATE INDEX IF NOT EXISTS idx_consent_records_owner_id ON consent_records(owner_id);
-CREATE INDEX IF NOT EXISTS idx_consent_records_owner_email ON consent_records(owner_email);
 CREATE INDEX IF NOT EXISTS idx_consent_records_app_id ON consent_records(app_id);
 CREATE INDEX IF NOT EXISTS idx_consent_records_status ON consent_records(status);
 CREATE INDEX IF NOT EXISTS idx_consent_records_created_at ON consent_records(created_at);
@@ -45,7 +44,7 @@ CREATE INDEX IF NOT EXISTS idx_consent_records_grant_expires_at ON consent_recor
 CREATE INDEX IF NOT EXISTS idx_consent_records_owner_app ON consent_records(owner_id, app_id);
 
 -- Add comment to table
-COMMENT ON TABLE consent_records IS 'Stores consent records with partial unique constraint on active consents (pending/approved). Multiple historical records (rejected, expired, revoked) are allowed per (owner_id, owner_email, app_id).';
+COMMENT ON TABLE consent_records IS 'Stores consent records with partial unique constraint on active consents (pending/approved). Multiple historical records (rejected, expired, revoked) are allowed per (owner_id, app_id).';
 
 -- To rollback this migration (DROP TABLE):
 -- DROP TABLE IF EXISTS consent_records CASCADE;

--- a/exchange/consent-engine/v1/migrations/drop_owner_email.sql
+++ b/exchange/consent-engine/v1/migrations/drop_owner_email.sql
@@ -1,0 +1,35 @@
+-- Migration: Drop owner_email from consent_records
+-- Date: 2026-07-17
+-- Description: Removes the owner_email column and rebuilds the active-consent
+--              uniqueness on (owner_id, app_id, status). In a DPI setup a user is
+--              identified system-wide by a single canonical UID (owner_id) only;
+--              email is no longer stored or used to key/authorize consents.
+--
+--              Run this against existing databases. Fresh databases created by
+--              add_consent_unique_tuple_constraint.sql (or GORM AutoMigrate) already
+--              have the correct shape and do not need this migration.
+--
+--              NOTE: If duplicate active consents exist for the same (owner_id, app_id)
+--              that previously differed only by owner_email, the unique index below
+--              will fail to create. Resolve those duplicates before running.
+
+BEGIN;
+
+-- Rebuild the partial unique index without owner_email
+DROP INDEX IF EXISTS idx_consent_active_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique
+    ON consent_records(owner_id, app_id, status)
+    WHERE status IN ('pending', 'approved');
+
+-- Drop the owner_email secondary index and column
+DROP INDEX IF EXISTS idx_consent_records_owner_email;
+ALTER TABLE consent_records DROP COLUMN IF EXISTS owner_email;
+
+-- Refresh table comment
+COMMENT ON TABLE consent_records IS 'Stores consent records with partial unique constraint on active consents (pending/approved). Multiple historical records (rejected, expired, revoked) are allowed per (owner_id, app_id).';
+
+COMMIT;
+
+-- To rollback (re-add the column as nullable; original values are not recoverable):
+-- ALTER TABLE consent_records ADD COLUMN IF NOT EXISTS owner_email VARCHAR(255);
+-- CREATE INDEX IF NOT EXISTS idx_consent_records_owner_email ON consent_records(owner_email);

--- a/exchange/consent-engine/v1/migrations/drop_owner_email.sql
+++ b/exchange/consent-engine/v1/migrations/drop_owner_email.sql
@@ -1,7 +1,7 @@
 -- Migration: Drop owner_email from consent_records
 -- Date: 2026-07-17
 -- Description: Removes the owner_email column and rebuilds the active-consent
---              uniqueness on (owner_id, app_id, status). In a DPI setup a user is
+--              uniqueness on (owner_id, app_id). In a DPI setup a user is
 --              identified system-wide by a single canonical UID (owner_id) only;
 --              email is no longer stored or used to key/authorize consents.
 --
@@ -9,16 +9,21 @@
 --              add_consent_unique_tuple_constraint.sql (or GORM AutoMigrate) already
 --              have the correct shape and do not need this migration.
 --
---              NOTE: If duplicate active consents exist for the same (owner_id, app_id)
---              that previously differed only by owner_email, the unique index below
---              will fail to create. Resolve those duplicates before running.
+--              NOTE: The rebuilt index is stricter than before — it drops both
+--              owner_email AND status from the key columns. If more than one active
+--              consent exists for the same (owner_id, app_id) — e.g. rows that
+--              previously differed only by owner_email, or a coexisting pending and
+--              approved row — the unique index below will fail to create. Resolve
+--              those duplicates before running.
 
 BEGIN;
 
--- Rebuild the partial unique index without owner_email
+-- Rebuild the partial unique index without owner_email.
+-- status stays only in the WHERE filter (not the key columns), so at most one
+-- active consent (pending OR approved) can exist per (owner_id, app_id).
 DROP INDEX IF EXISTS idx_consent_active_unique;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique
-    ON consent_records(owner_id, app_id, status)
+    ON consent_records(owner_id, app_id)
     WHERE status IN ('pending', 'approved');
 
 -- Drop the owner_email secondary index and column

--- a/exchange/consent-engine/v1/models/consent.go
+++ b/exchange/consent-engine/v1/models/consent.go
@@ -25,8 +25,10 @@ type ConsentRecord struct {
 	// AppName is the name of the consumer application
 	AppName *string `gorm:"column:app_name;type:varchar(255);" json:"app_name,omitempty"`
 	// Status is the status of the consent record: pending, approved, rejected, expired, revoked
-	// Part of conditional unique constraint for active consents (pending/approved)
-	Status string `gorm:"column:status;type:varchar(50);not null;index:idx_consent_records_status;uniqueIndex:idx_consent_active_unique,where:status = 'pending' OR status = 'approved'" json:"status"`
+	// Filters the conditional unique constraint (via its WHERE clause) but is
+	// deliberately NOT part of the index key, so a single (owner_id, app_id) can
+	// have at most one active (pending OR approved) consent.
+	Status string `gorm:"column:status;type:varchar(50);not null;index:idx_consent_records_status" json:"status"`
 	// Type is the type of consent mechanism "realtime" or "offline"
 	Type string `gorm:"column:type;type:varchar(50);not null" json:"type"`
 	// CreatedAt is the timestamp when the consent record was created

--- a/exchange/consent-engine/v1/models/consent.go
+++ b/exchange/consent-engine/v1/models/consent.go
@@ -8,18 +8,17 @@ import (
 
 // ConsentRecord represents a consent record in the system
 // Business Rules:
-// - Only one record can exist with status 'pending' or 'approved' for a given (OwnerID, OwnerEmail, AppID) tuple
+// - Only one record can exist with status 'pending' or 'approved' for a given (OwnerID, AppID) tuple
 // - Multiple records can exist with status 'revoked', 'expired', or 'rejected' for the same tuple
 // - The most recently created record should have status 'pending' or 'approved' (if active)
 type ConsentRecord struct {
 	// ConsentID is the unique identifier for the consent record
 	ConsentID uuid.UUID `gorm:"column:consent_id;type:uuid;primaryKey;default:gen_random_uuid()" json:"consent_id"`
-	// OwnerID is the unique identifier for the data owner
+	// OwnerID is the single canonical identifier (UID) for the data owner.
+	// The whole system relies on this UID to identify a user; a token claim
+	// (configurable) is matched against it during portal authorization.
 	// Part of conditional unique constraint for active consents (pending/approved)
 	OwnerID string `gorm:"column:owner_id;type:varchar(255);not null;index:idx_consent_records_owner_id;index:idx_consent_records_owner_app;uniqueIndex:idx_consent_active_unique,where:status = 'pending' OR status = 'approved'" json:"owner_id"`
-	// OwnerEmail is the email address of the data owner
-	// Part of conditional unique constraint for active consents (pending/approved)
-	OwnerEmail string `gorm:"column:owner_email;type:varchar(255);not null;index:idx_consent_records_owner_email;uniqueIndex:idx_consent_active_unique,where:status = 'pending' OR status = 'approved'" json:"owner_email"`
 	// AppID is the unique identifier for the consumer application
 	// Part of conditional unique constraint for active consents (pending/approved)
 	AppID string `gorm:"column:app_id;type:varchar(255);not null;index:idx_consent_records_app_id;index:idx_consent_records_owner_app;uniqueIndex:idx_consent_active_unique,where:status = 'pending' OR status = 'approved'" json:"app_id"`

--- a/exchange/consent-engine/v1/models/consent_test.go
+++ b/exchange/consent-engine/v1/models/consent_test.go
@@ -147,16 +147,15 @@ func TestConsentRecord_ToConsentResponseInternalView_PendingNoURL(t *testing.T) 
 func TestConsentRecord_ToConsentResponsePortalView(t *testing.T) {
 	appName := "Test App"
 	record := ConsentRecord{
-		ConsentID:  uuid.New(),
-		AppID:      "app-123",
-		AppName:    &appName,
-		OwnerID:    "owner-123",
-		OwnerEmail: "owner@example.com",
-		Status:     string(StatusApproved),
-		Type:       string(TypeRealtime),
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
-		Fields:     []ConsentField{{FieldName: "email", SchemaID: "schema-1", Owner: OwnerCitizen}},
+		ConsentID: uuid.New(),
+		AppID:     "app-123",
+		AppName:   &appName,
+		OwnerID:   "owner-123",
+		Status:    string(StatusApproved),
+		Type:      string(TypeRealtime),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Fields:    []ConsentField{{FieldName: "email", SchemaID: "schema-1", Owner: OwnerCitizen}},
 	}
 
 	response := record.ToConsentResponsePortalView()
@@ -165,7 +164,6 @@ func TestConsentRecord_ToConsentResponsePortalView(t *testing.T) {
 	assert.NotNil(t, response.AppName)
 	assert.Equal(t, appName, *response.AppName)
 	assert.Equal(t, record.OwnerID, response.OwnerID)
-	assert.Equal(t, record.OwnerEmail, response.OwnerEmail)
 	assert.Equal(t, ConsentStatus(record.Status), response.Status)
 	assert.Equal(t, ConsentType(record.Type), response.Type)
 	assert.Equal(t, record.CreatedAt, response.CreatedAt)
@@ -175,16 +173,15 @@ func TestConsentRecord_ToConsentResponsePortalView(t *testing.T) {
 
 func TestConsentRecord_ToConsentResponsePortalView_NoAppName(t *testing.T) {
 	record := ConsentRecord{
-		ConsentID:  uuid.New(),
-		AppID:      "app-123",
-		AppName:    nil,
-		OwnerID:    "owner-123",
-		OwnerEmail: "owner@example.com",
-		Status:     string(StatusApproved),
-		Type:       string(TypeRealtime),
-		CreatedAt:  time.Now(),
-		UpdatedAt:  time.Now(),
-		Fields:     []ConsentField{},
+		ConsentID: uuid.New(),
+		AppID:     "app-123",
+		AppName:   nil,
+		OwnerID:   "owner-123",
+		Status:    string(StatusApproved),
+		Type:      string(TypeRealtime),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Fields:    []ConsentField{},
 	}
 
 	response := record.ToConsentResponsePortalView()

--- a/exchange/consent-engine/v1/models/dtos.go
+++ b/exchange/consent-engine/v1/models/dtos.go
@@ -25,10 +25,9 @@ func (a ConsentField) Equals(b ConsentField) bool {
 
 // ConsentRequirement represents a consent requirement for a specific owner
 type ConsentRequirement struct {
-	Owner      OwnerType      `json:"owner"`
-	OwnerID    string         `json:"ownerId"`
-	OwnerEmail string         `json:"ownerEmail"`
-	Fields     []ConsentField `json:"fields"`
+	Owner   OwnerType      `json:"owner"`
+	OwnerID string         `json:"ownerId"`
+	Fields  []ConsentField `json:"fields"`
 }
 
 // CreateConsentRequest defines the structure for creating a consent record
@@ -59,15 +58,14 @@ type ConsentResponseInternalView struct {
 // ConsentResponsePortalView represents the user-facing consent object for the UI.
 // Uses rich field information for better UX in the consent portal
 type ConsentResponsePortalView struct {
-	AppID      string         `json:"appId"`
-	AppName    *string        `json:"appName"`
-	OwnerID    string         `json:"ownerId"`
-	OwnerEmail string         `json:"ownerEmail"`
-	Status     ConsentStatus  `json:"status"`
-	Type       ConsentType    `json:"type"`
-	CreatedAt  time.Time      `json:"createdAt"`
-	UpdatedAt  time.Time      `json:"updatedAt"`
-	Fields     []ConsentField `json:"fields"` // Rich field information with display names and descriptions
+	AppID     string         `json:"appId"`
+	AppName   *string        `json:"appName"`
+	OwnerID   string         `json:"ownerId"`
+	Status    ConsentStatus  `json:"status"`
+	Type      ConsentType    `json:"type"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	Fields    []ConsentField `json:"fields"` // Rich field information with display names and descriptions
 }
 
 // ToConsentResponseInternalView converts a ConsentRecord to a simplified ConsentResponseInternalView.
@@ -96,14 +94,13 @@ func (cr *ConsentRecord) ToConsentResponseInternalView() ConsentResponseInternal
 // Returns rich field information including display names and descriptions for better UX
 func (cr *ConsentRecord) ToConsentResponsePortalView() ConsentResponsePortalView {
 	return ConsentResponsePortalView{
-		AppID:      cr.AppID,
-		AppName:    cr.AppName,
-		OwnerID:    cr.OwnerID,
-		OwnerEmail: cr.OwnerEmail,
-		Status:     ConsentStatus(cr.Status),
-		Type:       ConsentType(cr.Type),
-		CreatedAt:  cr.CreatedAt,
-		UpdatedAt:  cr.UpdatedAt,
-		Fields:     cr.Fields, // Now includes DisplayName, Description, and Owner for rich UI rendering
+		AppID:     cr.AppID,
+		AppName:   cr.AppName,
+		OwnerID:   cr.OwnerID,
+		Status:    ConsentStatus(cr.Status),
+		Type:      ConsentType(cr.Type),
+		CreatedAt: cr.CreatedAt,
+		UpdatedAt: cr.UpdatedAt,
+		Fields:    cr.Fields, // Now includes DisplayName, Description, and Owner for rich UI rendering
 	}
 }

--- a/exchange/consent-engine/v1/openapi.yaml
+++ b/exchange/consent-engine/v1/openapi.yaml
@@ -75,7 +75,7 @@ paths:
         
         **Authorization:** Requires Bearer Token
         
-        **Ownership Verification:** The consent owner_email must match the email from the decoded token.
+        **Ownership Verification:** The consent owner_id must match the subject (UID) from the decoded token. The token claim that carries the UID is configurable (`IDP_SUBJECT_CLAIM`, default `sub`).
       operationId: getConsent
       tags:
         - External
@@ -155,7 +155,7 @@ paths:
         
         **Authorization:** Requires Bearer Token
         
-        **Ownership Verification:** The consent owner_email must match the email from the decoded token.
+        **Ownership Verification:** The consent owner_id must match the subject (UID) from the decoded token. The token claim that carries the UID is configurable (`IDP_SUBJECT_CLAIM`, default `sub`).
         
         **Valid Actions:**
         - `approve` - Approve the consent request
@@ -321,30 +321,22 @@ paths:
     get:
       summary: Get Consent by Owner and App
       description: |
-        Retrieves consent information by owner email/ID and application ID.
-        
+        Retrieves consent information by owner ID (the canonical UID) and application ID.
+
         **Query Parameters:**
-        - Either `ownerEmail` OR `ownerId` must be provided (not both)
+        - `ownerId` is required
         - `appId` is required
-        
+
         **Response:** Returns a simplified internal view of the consent record.
       operationId: getConsentInternal
       tags:
         - Internal
       security: []
       parameters:
-        - name: ownerEmail
-          in: query
-          required: false
-          description: The email address of the consent owner
-          schema:
-            type: string
-            format: email
-          example: "user@example.com"
         - name: ownerId
           in: query
-          required: false
-          description: The unique identifier of the consent owner
+          required: true
+          description: The canonical unique identifier (UID) of the consent owner
           schema:
             type: string
           example: "user123"
@@ -380,7 +372,7 @@ paths:
                   value:
                     error:
                       code: "BAD_REQUEST"
-                      message: "either ownerEmail or ownerId is required"
+                      message: "ownerId is required"
         '404':
           description: Consent not found
           content:
@@ -552,13 +544,8 @@ components:
           example: "citizen"
         ownerId:
           type: string
-          description: The unique identifier for the data owner
+          description: The canonical unique identifier (UID) for the data owner
           example: "user123"
-        ownerEmail:
-          type: string
-          format: email
-          description: The email address of the data owner
-          example: "user@example.com"
         fields:
           type: array
           description: List of fields requiring consent
@@ -567,7 +554,6 @@ components:
       required:
         - owner
         - ownerId
-        - ownerEmail
         - fields
 
     CreateConsentRequest:
@@ -616,7 +602,6 @@ components:
         consentRequirement:
           owner: "citizen"
           ownerId: "user123"
-          ownerEmail: "user@example.com"
           fields:
             - fieldName: "personInfo.name"
               schemaId: "schema-001"
@@ -686,13 +671,8 @@ components:
           example: "Passport Application"
         ownerId:
           type: string
-          description: The unique identifier of the data owner
+          description: The canonical unique identifier (UID) of the data owner
           example: "user123"
-        ownerEmail:
-          type: string
-          format: email
-          description: The email address of the data owner
-          example: "user@example.com"
         status:
           type: string
           enum: [pending, approved, rejected, expired, revoked]
@@ -721,7 +701,6 @@ components:
       required:
         - appId
         - ownerId
-        - ownerEmail
         - status
         - type
         - createdAt
@@ -731,7 +710,6 @@ components:
         appId: "app-12345"
         appName: "Passport Application"
         ownerId: "user123"
-        ownerEmail: "user@example.com"
         status: "pending"
         type: "realtime"
         createdAt: "2023-12-09T10:30:00Z"

--- a/exchange/consent-engine/v1/services/consent_service.go
+++ b/exchange/consent-engine/v1/services/consent_service.go
@@ -37,8 +37,8 @@ func (s *ConsentService) CreateConsentRecord(ctx context.Context, req models.Cre
 		return nil, fmt.Errorf("%w: %w", models.ErrConsentCreateFailed, err)
 	}
 
-	// First Check if a pending or approved consent already exists for the same (ownerID/ownerEmail, appID)
-	existingConsent, err := s.GetConsentInternalView(ctx, nil, &req.ConsentRequirement.OwnerID, &req.ConsentRequirement.OwnerEmail, &req.AppID)
+	// First Check if a pending or approved consent already exists for the same (ownerID, appID)
+	existingConsent, err := s.GetConsentInternalView(ctx, nil, &req.ConsentRequirement.OwnerID, &req.AppID)
 	if err == nil {
 		// An existing consent was found
 		if existingConsent.Status == string(models.StatusPending) || existingConsent.Status == string(models.StatusApproved) {
@@ -148,7 +148,6 @@ func (s *ConsentService) buildConsentRecord(req models.CreateConsentRequest) (*m
 	return &models.ConsentRecord{
 		ConsentID:        consentID,
 		OwnerID:          req.ConsentRequirement.OwnerID,
-		OwnerEmail:       req.ConsentRequirement.OwnerEmail,
 		AppID:            req.AppID,
 		AppName:          req.AppName,
 		Status:           string(models.StatusPending),
@@ -170,8 +169,8 @@ func getGrantDurationOrDefault(grantDuration *models.GrantDuration) models.Grant
 	return *grantDuration
 }
 
-// GetConsentInternalView retrieves a consent record by ID or by ((ownerID OR ownerEmail) AND appID) and returns its internal view
-func (s *ConsentService) GetConsentInternalView(ctx context.Context, consentID *string, ownerID *string, ownerEmail *string, appID *string) (*models.ConsentResponseInternalView, error) {
+// GetConsentInternalView retrieves a consent record by ID or by (ownerID AND appID) and returns its internal view
+func (s *ConsentService) GetConsentInternalView(ctx context.Context, consentID *string, ownerID *string, appID *string) (*models.ConsentResponseInternalView, error) {
 	var consentRecord models.ConsentRecord
 	query := s.db.WithContext(ctx).Model(&models.ConsentRecord{})
 
@@ -182,17 +181,12 @@ func (s *ConsentService) GetConsentInternalView(ctx context.Context, consentID *
 		}
 		query = query.Where("consent_id = ?", parsedConsentID)
 	} else if ownerID != nil && appID != nil {
-		// OwnerID gets priority over OwnerEmail if both are provided
 		query = query.Where("owner_id = ? AND app_id = ?", *ownerID, *appID)
-	} else if ownerEmail != nil && appID != nil {
-		// NOTE: This query on (owner_email, app_id) does not benefit from a composite index.
-		// If this query pattern is common or the table is large, consider adding a composite index on (owner_email, app_id)
-		query = query.Where("owner_email = ? AND app_id = ?", *ownerEmail, *appID)
 	} else {
-		return nil, fmt.Errorf("%w: either consentID or (ownerID/ownerEmail and appID) must be provided", models.ErrConsentGetFailed)
+		return nil, fmt.Errorf("%w: either consentID or (ownerID and appID) must be provided", models.ErrConsentGetFailed)
 	}
 
-	// There is a possibility of multiple records for (ownerID/ownerEmail, appID) if previous consents exist.
+	// There is a possibility of multiple records for (ownerID, appID) if previous consents exist.
 	// We fetch the latest one based on CreatedAt timestamp.
 	// We can safely assume CreatedAt is unique for active consents due to the conditional unique constraint.
 	query = query.Order("created_at DESC").Limit(1)
@@ -386,9 +380,6 @@ func validateCreateConsentRequest(req models.CreateConsentRequest) error {
 
 	if req.ConsentRequirement.OwnerID == "" {
 		return fmt.Errorf("consentRequirement.ownerId is required")
-	}
-	if req.ConsentRequirement.OwnerEmail == "" {
-		return fmt.Errorf("consentRequirement.ownerEmail is required")
 	}
 	if len(req.ConsentRequirement.Fields) == 0 {
 		return fmt.Errorf("consentRequirement.fields cannot be empty")

--- a/tests/integration/consent/consent_test.go
+++ b/tests/integration/consent/consent_test.go
@@ -26,10 +26,9 @@ type ConsentField struct {
 }
 
 type ConsentRequirement struct {
-	Owner      string         `json:"owner"`
-	OwnerID    string         `json:"ownerId"`
-	OwnerEmail string         `json:"ownerEmail"`
-	Fields     []ConsentField `json:"fields"`
+	Owner   string         `json:"owner"`
+	OwnerID string         `json:"ownerId"`
+	Fields  []ConsentField `json:"fields"`
 }
 
 type CreateConsentRequest struct {
@@ -81,9 +80,8 @@ func TestConsent_CreateAndRetrieve(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: fieldName,
@@ -146,10 +144,9 @@ func TestConsent_InvalidRequest(t *testing.T) {
 			request: func() []byte {
 				req := map[string]interface{}{
 					"consentRequirement": map[string]interface{}{
-						"owner":      "citizen",
-						"ownerId":    "test-owner",
-						"ownerEmail": "test@example.com",
-						"fields":     []map[string]interface{}{},
+						"owner":   "citizen",
+						"ownerId": "test-owner",
+						"fields":  []map[string]interface{}{},
 					},
 				}
 				body, _ := json.Marshal(req)
@@ -174,9 +171,8 @@ func TestConsent_InvalidRequest(t *testing.T) {
 				req := map[string]interface{}{
 					"appId": "test-app",
 					"consentRequirement": map[string]interface{}{
-						"owner":      "citizen",
-						"ownerEmail": "test@example.com",
-						"fields":     []map[string]interface{}{},
+						"owner":  "citizen",
+						"fields": []map[string]interface{}{},
 					},
 				}
 				body, _ := json.Marshal(req)
@@ -190,10 +186,9 @@ func TestConsent_InvalidRequest(t *testing.T) {
 				req := CreateConsentRequest{
 					AppID: "test-app",
 					ConsentRequirement: ConsentRequirement{
-						Owner:      "citizen",
-						OwnerID:    "test-owner",
-						OwnerEmail: "test@example.com",
-						Fields:     []ConsentField{},
+						Owner:   "citizen",
+						OwnerID: "test-owner",
+						Fields:  []ConsentField{},
 					},
 				}
 				body, _ := json.Marshal(req)
@@ -226,9 +221,8 @@ func TestConsent_GetByConsumer(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: "personInfo.name",
@@ -285,9 +279,8 @@ func TestConsent_StatusUpdate(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: "personInfo.name",
@@ -354,9 +347,8 @@ func TestConsent_DatabaseVerification(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: "personInfo.name",
@@ -397,60 +389,21 @@ func TestConsent_DatabaseVerification(t *testing.T) {
 	})
 }
 
-// TestConsent_GetByOwnerEmail tests retrieving consent by owner email
-func TestConsent_GetByOwnerEmail(t *testing.T) {
+// TestConsent_GetByOwnerEmailNoLongerSupported verifies that lookups by the
+// removed ownerEmail query parameter are rejected: a user is identified only by
+// the canonical ownerId (UID), so ownerEmail alone no longer satisfies the
+// required owner identifier.
+func TestConsent_GetByOwnerEmailNoLongerSupported(t *testing.T) {
 	appID := "test-app-email-1"
-	ownerID := "test-owner-email-1"
-	ownerEmail := ownerID + "@example.com"
+	ownerEmail := "test-owner-email-1@example.com"
 
-	// Create consent
-	createReq := CreateConsentRequest{
-		AppID: appID,
-		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerEmail,
-			Fields: []ConsentField{
-				{
-					FieldName: "personInfo.name",
-					SchemaID:  "test-schema-123",
-				},
-			},
-		},
-	}
-
-	reqBody, err := json.Marshal(createReq)
-	require.NoError(t, err)
-
-	resp, err := http.Post(consentBaseURL+"/internal/api/v1/consents", "application/json", bytes.NewBuffer(reqBody))
+	// The ownerEmail parameter is no longer recognized; without ownerId the
+	// request is missing its required owner identifier and must return 400.
+	resp, err := http.Get(consentBaseURL + "/internal/api/v1/consents?ownerEmail=" + url.QueryEscape(ownerEmail) + "&appId=" + appID)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
-
-	var createResponse CreateConsentResponse
-	err = json.NewDecoder(resp.Body).Decode(&createResponse)
-	require.NoError(t, err)
-
-	consentID := createResponse.ConsentID
-	require.NotEmpty(t, consentID)
-
-	// Cleanup
-	t.Cleanup(func() {
-		testutils.CleanupConsentRecord(t, consentID)
-	})
-
-	// Retrieve by owner email
-	resp, err = http.Get(consentBaseURL + "/internal/api/v1/consents?ownerEmail=" + url.QueryEscape(ownerEmail) + "&appId=" + appID)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "Should return 200 OK")
-
-	var retrievedConsent CreateConsentResponse
-	err = json.NewDecoder(resp.Body).Decode(&retrievedConsent)
-	require.NoError(t, err)
-	assert.Equal(t, consentID, retrievedConsent.ConsentID, "Retrieved consent ID should match created consent")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "ownerEmail lookups should return 400 Bad Request")
 }
 
 // TestConsent_MultipleFields tests creating consent with multiple fields
@@ -462,9 +415,8 @@ func TestConsent_MultipleFields(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: "personInfo.name",
@@ -530,9 +482,9 @@ func TestConsent_MissingAppId(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Should return 400 Bad Request for missing appId")
 }
 
-// TestConsent_MissingOwnerIdentifier tests GET request without ownerEmail or ownerId
+// TestConsent_MissingOwnerIdentifier tests GET request without ownerId
 func TestConsent_MissingOwnerIdentifier(t *testing.T) {
-	// Try to retrieve consent without ownerEmail or ownerId (required parameter)
+	// Try to retrieve consent without ownerId (required parameter)
 	resp, err := http.Get(consentBaseURL + "/internal/api/v1/consents?appId=test-app")
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -548,9 +500,8 @@ func TestConsent_DuplicateCreation(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: "personInfo.name",
@@ -616,9 +567,8 @@ func TestConsent_DifferentSchemas(t *testing.T) {
 	createReq := CreateConsentRequest{
 		AppID: appID,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      "citizen",
-			OwnerID:    ownerID,
-			OwnerEmail: ownerID + "@example.com",
+			Owner:   "citizen",
+			OwnerID: ownerID,
 			Fields: []ConsentField{
 				{
 					FieldName: "personInfo.name",

--- a/tests/integration/graphql_flow_test.go
+++ b/tests/integration/graphql_flow_test.go
@@ -371,13 +371,11 @@ func updatePDPAllowlist(t *testing.T, appID, schemaID, fieldName string) {
 
 // createConsent creates a consent record in the Consent Engine and returns the consent ID.
 func createConsent(t *testing.T, appID, schemaID, fieldName, ownerID string) string {
-	// Use testEmail for ownerEmail (required by V1 API)
 	consentReq := map[string]interface{}{
 		"appId": appID,
 		"consentRequirement": map[string]interface{}{
-			"owner":      "citizen",
-			"ownerId":    ownerID,
-			"ownerEmail": testEmail,
+			"owner":   "citizen",
+			"ownerId": ownerID,
 			"fields": []map[string]interface{}{
 				{
 					"fieldName": fieldName,
@@ -423,30 +421,30 @@ func createConsent(t *testing.T, appID, schemaID, fieldName, ownerID string) str
 }
 
 // approveConsent attempts to approve a consent record using PUT /api/v1/consents/{consentId} endpoint.
-// Requires JWT authentication with email claim matching the consent owner_email.
+// Requires JWT authentication with the subject claim matching the consent owner_id.
 // Note: The JWT verifier requires RSA-signed tokens. This function uses unsigned tokens for testing,
 // which will fail in environments where RSA-signed tokens are required. The function logs a warning
 // and returns without failing the test, as the test can proceed without explicit approval.
 func approveConsent(t *testing.T, consentID string) {
-	// Get the consent from DB to retrieve owner_email for JWT token
+	// Get the consent from DB to retrieve owner_id for the JWT subject
 	// (Internal API doesn't support getting by consentId directly)
 	db := getConsentDB(t)
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
 	defer sqlDB.Close()
 
-	var ownerEmail string
-	err = db.Raw("SELECT owner_email FROM consent_records WHERE consent_id = ?", consentID).Scan(&ownerEmail).Error
-	require.NoError(t, err, "Failed to get consent owner_email from DB")
-	require.NotEmpty(t, ownerEmail, "Consent must have owner_email")
+	var ownerID string
+	err = db.Raw("SELECT owner_id FROM consent_records WHERE consent_id = ?", consentID).Scan(&ownerID).Error
+	require.NoError(t, err, "Failed to get consent owner_id from DB")
+	require.NotEmpty(t, ownerID, "Consent must have owner_id")
 
-	// Create JWT token with email claim matching the consent owner_email
+	// Create JWT token with the subject (sub) claim matching the consent owner_id
 	// Note: The JWT verifier requires RSA signing, but in test environments unsigned tokens
 	// may be accepted if the consent engine is configured appropriately
 	claims := jwt.MapClaims{
-		"email": ownerEmail,
-		"iss":   "https://accounts.google.com", // Required by JWT verifier
-		"aud":   "test-audience",               // Required by JWT verifier
+		"sub": ownerID,
+		"iss": "https://accounts.google.com", // Required by JWT verifier
+		"aud": "test-audience",               // Required by JWT verifier
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
 	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
@@ -566,13 +564,11 @@ func TestGraphQLFlow_SuccessPath(t *testing.T) {
 					}
 				}
 			}
-			// Check if error is CE_ERROR - this might indicate OE/CE API format mismatch
-			// OE uses old format (ConsentRequirement with OwnerEmail) but CE might expect new format
+			// Check if error is CE_ERROR - this might indicate an OE/CE API mismatch
 			firstError := errors[0].(map[string]interface{})
 			if ext, ok := firstError["extensions"].(map[string]interface{}); ok {
 				if code, ok := ext["code"].(string); ok && code == "CE_ERROR" {
-					t.Logf("WARNING: CE_ERROR detected. This may indicate OE/CE API format mismatch.")
-					t.Logf("OE uses old format (ConsentRequirement with OwnerEmail), CE may expect new format.")
+					t.Logf("WARNING: CE_ERROR detected. This may indicate an OE/CE API mismatch.")
 					// Don't fail the test - this is a known issue that needs OE code update
 					return
 				}

--- a/tests/integration/init-consent-db.sql
+++ b/tests/integration/init-consent-db.sql
@@ -28,4 +28,6 @@ CREATE INDEX IF NOT EXISTS idx_consent_records_grant_expires_at ON consent_recor
 CREATE INDEX IF NOT EXISTS idx_consent_records_owner_app ON consent_records (owner_id, app_id);
 
 -- Create partial unique index for active consents
-CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique ON consent_records (owner_id, app_id, status) WHERE status IN ('pending', 'approved');
+-- status is kept only in the WHERE filter (not the key) so at most one active
+-- consent (pending OR approved) can exist per (owner_id, app_id).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique ON consent_records (owner_id, app_id) WHERE status IN ('pending', 'approved');

--- a/tests/integration/init-consent-db.sql
+++ b/tests/integration/init-consent-db.sql
@@ -2,7 +2,6 @@
 CREATE TABLE IF NOT EXISTS consent_records (
     consent_id uuid DEFAULT gen_random_uuid(),
     owner_id varchar(255) NOT NULL,
-    owner_email varchar(255) NOT NULL,
     app_id varchar(255) NOT NULL,
     app_name varchar(255),
     status varchar(50) NOT NULL,
@@ -21,7 +20,6 @@ CREATE TABLE IF NOT EXISTS consent_records (
 
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_consent_records_owner_id ON consent_records (owner_id);
-CREATE INDEX IF NOT EXISTS idx_consent_records_owner_email ON consent_records (owner_email);
 CREATE INDEX IF NOT EXISTS idx_consent_records_app_id ON consent_records (app_id);
 CREATE INDEX IF NOT EXISTS idx_consent_records_status ON consent_records (status);
 CREATE INDEX IF NOT EXISTS idx_consent_records_created_at ON consent_records (created_at);
@@ -30,4 +28,4 @@ CREATE INDEX IF NOT EXISTS idx_consent_records_grant_expires_at ON consent_recor
 CREATE INDEX IF NOT EXISTS idx_consent_records_owner_app ON consent_records (owner_id, app_id);
 
 -- Create partial unique index for active consents
-CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique ON consent_records (owner_id, owner_email, app_id, status) WHERE status IN ('pending', 'approved');
+CREATE UNIQUE INDEX IF NOT EXISTS idx_consent_active_unique ON consent_records (owner_id, app_id, status) WHERE status IN ('pending', 'approved');


### PR DESCRIPTION
## Summary

In a Digital Public Infrastructure setup a user should be identified system-wide by a single canonical UID, not by an email. Today the consent-engine stores an `OwnerEmail` alongside `OwnerID` (the two are always the same string), and it hardwires the JWT `email` claim as the identity used to authorize portal actions.

This PR removes the email-based identity from the consent-engine and makes the token claim that carries the owner UID configurable. It is split into two commits: (1) remove email, (2) add the configurable claim.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

> Breaking: the `owner_email` column and the `ownerEmail` API surface are removed; existing databases require a manual migration (see Deployment Notes).

## Changes Made

**Commit 1 — `refactor: identify data owner by single UID, drop owner_email`**
- Removed `OwnerEmail` from `ConsentRecord`, `ConsentRequirement`, and `ConsentResponsePortalView`. The active-consent partial unique constraint is now keyed on `(owner_id, app_id)`.
- Removed the `ownerEmail` lookup path from the internal `GET /internal/api/v1/consents` handler and from `GetConsentInternalView` (lookups key on `(ownerId, appId)` only).
- Portal authorization now compares `consent.OwnerID` against the token subject instead of comparing `owner_email` to the `email` claim.
- Verifier extracts the owner UID from the standard OIDC `sub` claim (`VerifyTokenAndExtractSubject`); middleware context renamed to `ownerSubject` (`GetOwnerSubjectFromContext`).
- Added `v1/migrations/drop_owner_email.sql` for existing databases and updated the base migration for fresh installs.

**Commit 2 — `feat: make the owner-UID token claim configurable`**
- Added `IDP_SUBJECT_CLAIM` (default `sub`) → `IDPConfig.SubjectClaim` → `JWTVerifierConfig.SubjectClaim`, threaded through `main.go` and logged at startup.
- `VerifyTokenAndExtractSubject` reads the configured claim, falling back to `DefaultSubjectClaim` (`sub`) when unset — so each IdP can declare which claim carries the UID (e.g. `sub`, `email`, `individual_id`).
- Documented the variable in `README.md` and `.env.example`.

## Testing

- [x] I have tested this change locally
- [x] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

Unit tests updated/added: subject extraction defaults to `sub`, uses a configured claim, and fails when the configured claim is missing; middleware/handler tests updated to the subject/UID model. Full `go build`, `go vet`, and `go test ./...` pass; both commits passed the repo pre-commit validation (quality + build + tests).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #477

## Additional Notes

Scope is limited to `exchange/consent-engine/`. The orchestration-engine still sends an `ownerEmail` field and seeds `OwnerID` positionally from `extractedArgs[0]`; the consent-engine now ignores the extra field. Aligning OE to seed `OwnerID` from the same claim the CE matches is a tracked follow-up (see `docs/FLOW-graphql-policy-consent-and-esignet-gap.md` §7), and is the precondition for the eSignet citizen-authentication work.

## Deployment Notes

- **Manual DB migration required for existing databases.** `AutoMigrate` does not drop columns/indexes, so run `v1/migrations/drop_owner_email.sql` to drop the `owner_email` column, drop `idx_consent_records_owner_email`, and rebuild `idx_consent_active_unique` on `(owner_id, app_id, status)`. The migration aborts if duplicate active consents exist that previously differed only by `owner_email`; resolve those first.
- **Config:** set `IDP_SUBJECT_CLAIM` to the claim that carries the owner UID for your IdP (defaults to `sub`). Ensure the value in that claim matches the `owner_id` seeded when consents are created.
