### PR TITLE
refactor(orchestration-engine): replace go-chi with native net/http.ServeMux

### DIFF
--- a/exchange/orchestration-engine/go.mod
+++ b/exchange/orchestration-engine/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/LSFLK/argus/pkg/audit v0.0.0-20260622104753-c28bd76815b0
 	github.com/MicahParks/keyfunc/v3 v3.7.0
 	github.com/OpenNDX/openndx-core/exchange/shared/monitoring v0.0.0-20260715091746-eb892d24b2e1
-	github.com/go-chi/chi/v5 v5.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/graphql-go/graphql v0.8.1

--- a/exchange/orchestration-engine/go.sum
+++ b/exchange/orchestration-engine/go.sum
@@ -14,8 +14,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
-github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/exchange/orchestration-engine/handlers/schema.go
+++ b/exchange/orchestration-engine/handlers/schema.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/logger"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/services"
-	"github.com/go-chi/chi/v5"
 )
 
 // SchemaService defines the behavior SchemaHandler depends on.
@@ -129,8 +128,8 @@ func (h *SchemaHandler) ActivateSchema(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract version from URL path (simplified)
-	version := chi.URLParam(r, "version")
+	// Extract version from URL path
+	version := r.PathValue("version")
 
 	err := h.schemaService.ActivateSchema(version)
 	if err != nil {

--- a/exchange/orchestration-engine/handlers/schema_test.go
+++ b/exchange/orchestration-engine/handlers/schema_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/logger"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/services"
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -138,12 +136,8 @@ func TestSchemaHandler_ActivateSchema_NoService(t *testing.T) {
 	handler := NewSchemaHandler(nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/sdl/versions/1.0.0/activate", nil)
+	req.SetPathValue("version", "1.0.0")
 	w := httptest.NewRecorder()
-
-	// Use chi router to set URL param
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("version", "1.0.0")
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	handler.ActivateSchema(w, req)
 
@@ -162,11 +156,8 @@ func TestSchemaHandler_ActivateSchema_Success(t *testing.T) {
 	handler := NewSchemaHandler(mockService)
 
 	req := httptest.NewRequest(http.MethodPost, "/sdl/versions/1.0.0/activate", nil)
+	req.SetPathValue("version", "1.0.0")
 	w := httptest.NewRecorder()
-
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("version", "1.0.0")
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	handler.ActivateSchema(w, req)
 

--- a/exchange/orchestration-engine/server/server.go
+++ b/exchange/orchestration-engine/server/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/logger"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/pkg/graphql"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/services"
-	"github.com/go-chi/chi/v5"
 )
 
 type Response struct {
@@ -83,8 +82,8 @@ func RunServer(ctx context.Context, f *federator.Federator) {
 }
 
 // SetupRouter initializes the router and registers all endpoints
-func SetupRouter(f *federator.Federator) *chi.Mux {
-	mux := chi.NewRouter()
+func SetupRouter(f *federator.Federator) *http.ServeMux {
+	mux := http.NewServeMux()
 
 	// Initialize database connection
 	dbConnectionString := getDatabaseConnectionString()
@@ -110,11 +109,7 @@ func SetupRouter(f *federator.Federator) *chi.Mux {
 	// Set the schema service in the federator
 	f.SchemaService = schemaService
 	// /health route
-	mux.Get("/health", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		resp := Response{Message: "OpenNDX Server is Healthy!"}
 		w.Header().Set("Content-Type", "application/json")
 		err := json.NewEncoder(w).Encode(resp)
@@ -124,17 +119,17 @@ func SetupRouter(f *federator.Federator) *chi.Mux {
 	})
 
 	// Schema management routes
-	mux.Get("/sdl", schemaHandler.GetActiveSchema)
-	mux.Post("/sdl", schemaHandler.CreateSchema)
-	mux.Get("/sdl/versions", schemaHandler.GetSchemas)
-	mux.Post("/sdl/validate", schemaHandler.ValidateSDL)
-	mux.Post("/sdl/check-compatibility", schemaHandler.CheckCompatibility)
+	mux.HandleFunc("GET /sdl", schemaHandler.GetActiveSchema)
+	mux.HandleFunc("POST /sdl", schemaHandler.CreateSchema)
+	mux.HandleFunc("GET /sdl/versions", schemaHandler.GetSchemas)
+	mux.HandleFunc("POST /sdl/validate", schemaHandler.ValidateSDL)
+	mux.HandleFunc("POST /sdl/check-compatibility", schemaHandler.CheckCompatibility)
 
 	// Handle activation endpoint with proper path matching
-	mux.Post("/sdl/versions/{version}/activate", schemaHandler.ActivateSchema)
+	mux.HandleFunc("POST /sdl/versions/{version}/activate", schemaHandler.ActivateSchema)
 
 	// Publicly accessible Endpoints
-	mux.Post("/public/graphql", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /public/graphql", func(w http.ResponseWriter, r *http.Request) {
 		// Parse request body
 		var req graphql.Request
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {


### PR DESCRIPTION
## Summary

Replaces the third-party `github.com/go-chi/chi/v5` router in the orchestration-engine with Go's standard-library `net/http.ServeMux`. The engine targets Go 1.24.6, so the stdlib router fully supports the only chi features in use — method-based routing (`GET /path`) and path wildcards (`/{version}`). This drops an external dependency with no loss of functionality.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **`server/server.go`**: `SetupRouter` now returns `*http.ServeMux` (was `*chi.Mux`); `chi.NewRouter()` → `http.NewServeMux()`. All routes converted to method-pattern registrations, e.g. `mux.Get("/sdl", …)` → `mux.HandleFunc("GET /sdl", …)`, including `POST /sdl/versions/{version}/activate`. Removed the now-redundant manual method check in the `/health` handler (the `GET` pattern enforces it). Dropped the chi import.
- **`handlers/schema.go`**: `chi.URLParam(r, "version")` → `r.PathValue("version")`; dropped the chi import.
- **`handlers/schema_test.go`**: replaced chi route-context setup with `req.SetPathValue("version", …)`; dropped the `context` and chi imports.
- **`go.mod` / `go.sum`**: removed `github.com/go-chi/chi/v5` via `go mod tidy`.

No sub-routers, route groups, or chi-specific middleware were in use. `corsMiddleware` and `middleware/audit_middleware.go` are already plain `http.Handler` and needed no changes.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [x] I have tested edge cases
- [x] All existing tests pass

`go build ./...` and `go test ./...` both pass. Route behavior is unchanged (same methods, paths, and `{version}` path param). Go 1.22+ `ServeMux` returns `405 Method Not Allowed` on method mismatches automatically, matching prior behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #483

## Additional Notes

Mechanical, low-risk migration — no behavioral changes to any endpoint.
