### PR TITLE
refactor: remove ownerEmail from consent request (sync OE to cleaned CE contract)

### DIFF
--- a/exchange/orchestration-engine/consent/ce_client_test.go
+++ b/exchange/orchestration-engine/consent/ce_client_test.go
@@ -101,9 +101,8 @@ func TestCreateConsent_Success(t *testing.T) {
 		AppID:   "test-app-id",
 		AppName: &appName,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
 			Fields: []ConsentField{
 				{
 					FieldName:   "name",
@@ -162,10 +161,9 @@ func TestCreateConsent_MarshalError(t *testing.T) {
 	request := &CreateConsentRequest{
 		AppID: "test-app-id",
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
-			Fields:     []ConsentField{},
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
+			Fields:  []ConsentField{},
 		},
 	}
 
@@ -187,10 +185,9 @@ func TestCreateConsent_HTTPRequestError(t *testing.T) {
 	request := &CreateConsentRequest{
 		AppID: "test-app-id",
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
-			Fields:     []ConsentField{},
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
+			Fields:  []ConsentField{},
 		},
 	}
 
@@ -216,10 +213,9 @@ func TestCreateConsent_NonCreatedStatusCode(t *testing.T) {
 	request := &CreateConsentRequest{
 		AppID: "test-app-id",
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
-			Fields:     []ConsentField{},
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
+			Fields:  []ConsentField{},
 		},
 	}
 
@@ -250,10 +246,9 @@ func TestCreateConsent_InvalidResponseBody(t *testing.T) {
 	request := &CreateConsentRequest{
 		AppID: "test-app-id",
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
-			Fields:     []ConsentField{},
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
+			Fields:  []ConsentField{},
 		},
 	}
 
@@ -282,10 +277,9 @@ func TestCreateConsent_ContextCancellation(t *testing.T) {
 	request := &CreateConsentRequest{
 		AppID: "test-app-id",
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
-			Fields:     []ConsentField{},
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
+			Fields:  []ConsentField{},
 		},
 	}
 
@@ -340,9 +334,8 @@ func TestCreateConsent_WithAllOptionalFields(t *testing.T) {
 		GrantDuration: &grantDuration,
 		ConsentType:   &consentType,
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
 			Fields: []ConsentField{
 				{
 					FieldName: "name",
@@ -397,9 +390,8 @@ func TestCreateConsent_WithMinimalFields(t *testing.T) {
 	request := &CreateConsentRequest{
 		AppID: "test-app-id",
 		ConsentRequirement: ConsentRequirement{
-			Owner:      OwnerCitizen,
-			OwnerID:    "citizen-123",
-			OwnerEmail: "citizen@example.com",
+			Owner:   OwnerCitizen,
+			OwnerID: "citizen-123",
 			Fields: []ConsentField{
 				{
 					FieldName: "name",

--- a/exchange/orchestration-engine/consent/dtos.go
+++ b/exchange/orchestration-engine/consent/dtos.go
@@ -12,10 +12,9 @@ type ConsentField struct {
 
 // ConsentRequirement represents a consent requirement for a specific owner
 type ConsentRequirement struct {
-	Owner      OwnerType      `json:"owner"`
-	OwnerID    string         `json:"ownerId"`
-	OwnerEmail string         `json:"ownerEmail"`
-	Fields     []ConsentField `json:"fields"`
+	Owner   OwnerType      `json:"owner"`
+	OwnerID string         `json:"ownerId"`
+	Fields  []ConsentField `json:"fields"`
 }
 
 // CreateConsentRequest defines the structure for creating a consent record

--- a/exchange/orchestration-engine/federator/federator.go
+++ b/exchange/orchestration-engine/federator/federator.go
@@ -412,8 +412,6 @@ func (f *Federator) FederateQuery(ctx context.Context, request graphql.Request, 
 			return createErrorResponseWithCode("Consent required but consent engine not available", errors.CodeCEError)
 		}
 
-		ownerEmail := dataOwnerID // assuming dataOwnerID is ownerEmail for this example
-
 		// Map PDP response fields to Consent Engine request with all metadata
 		fields := make([]consent.ConsentField, len(pdpResponse.ConsentRequiredFields))
 		for i, f := range pdpResponse.ConsentRequiredFields {
@@ -434,10 +432,9 @@ func (f *Federator) FederateQuery(ctx context.Context, request graphql.Request, 
 		ceRequest := &consent.CreateConsentRequest{
 			AppID: consumerInfo.ApplicationID,
 			ConsentRequirement: consent.ConsentRequirement{
-				Owner:      consent.OwnerCitizen,
-				OwnerID:    ownerEmail,
-				OwnerEmail: ownerEmail,
-				Fields:     fields,
+				Owner:   consent.OwnerCitizen,
+				OwnerID: dataOwnerID,
+				Fields:  fields,
 			},
 			ConsentType: &typeRealTime,
 		}
@@ -446,7 +443,7 @@ func (f *Federator) FederateQuery(ctx context.Context, request graphql.Request, 
 
 		// Log consent check audit event
 		// Update context with traceID if one was generated
-		ctx = f.logConsentCheck(ctx, consumerInfo.ApplicationID, ownerEmail, ownerEmail, ceRequest, ceResp, err)
+		ctx = f.logConsentCheck(ctx, consumerInfo.ApplicationID, dataOwnerID, ceRequest, ceResp, err)
 
 		if err != nil {
 			logger.Log.Info("CE request failed", "error", err)
@@ -649,7 +646,7 @@ func (f *Federator) logPolicyCheck(ctx context.Context, applicationID string, re
 // logConsentCheck logs a CONSENT_CHECK event from orchestration-engine's perspective
 // This is called after making a request to the Consent Engine
 // Returns the updated context with traceID to ensure trace correlation
-func (f *Federator) logConsentCheck(ctx context.Context, applicationID, ownerEmail, ownerID string, req *consent.CreateConsentRequest, resp *consent.ConsentResponseInternalView, err error) context.Context {
+func (f *Federator) logConsentCheck(ctx context.Context, applicationID, ownerID string, req *consent.CreateConsentRequest, resp *consent.ConsentResponseInternalView, err error) context.Context {
 	targetID := "consent-engine"
 	status := auditpkg.StatusSuccess
 	requestMetadata := make(map[string]interface{})
@@ -657,9 +654,6 @@ func (f *Federator) logConsentCheck(ctx context.Context, applicationID, ownerEma
 
 	// Populate request metadata from request context
 	requestMetadata["applicationId"] = applicationID
-	if ownerEmail != "" {
-		requestMetadata["ownerEmail"] = ownerEmail
-	}
 	if ownerID != "" {
 		requestMetadata["ownerId"] = ownerID
 	}


### PR DESCRIPTION
## Summary

The Consent Engine (CE) cleaned up its consent-creation contract and removed `ownerEmail` from `ConsentRequirement` — `OwnerID` is now the single canonical owner identifier (UID). This PR syncs the Orchestration Engine (OE) to that contract so it stops sending a field CE no longer accepts, and drops the misleading "owner id is an email" conflation from OE's DTO, request builder, and audit log.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe):

> Wire-contract change between OE and CE. It is not a behavior change to the consent decision, but OE and CE must be deployed together (see Deployment Notes).

## Changes Made

- **`consent/dtos.go`** — removed `OwnerEmail` from `ConsentRequirement`, mirroring CE's `internal/models/dtos.go` (`{Owner, OwnerID, Fields}`).
- **`federator/federator.go`**:
  - Removed the `ownerEmail := dataOwnerID` alias; `OwnerID` is now set directly from `dataOwnerID`.
  - Collapsed `logConsentCheck`'s duplicate `ownerEmail, ownerID` params into a single `ownerID`, and dropped the `ownerEmail` audit-metadata entry (`ownerId` is still logged).
- **`consent/ce_client_test.go`** — removed the now-invalid `OwnerEmail` fields from the request literals.

## Testing

- [x] I have tested this change locally
- [ ] I have added unit tests for new functionality
- [ ] I have tested edge cases
- [x] All existing tests pass

`go build ./...`, `go vet ./...`, and the full OE test suite all pass; `gofmt` clean. No new unit tests added — this is a contract-sync with no new functionality; existing `consent`/`federator` tests cover the path.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that there are no merge conflicts

## Related Issues

Closes #486

## Additional Notes

Out of scope (follow-up): OE still seeds `OwnerID` from `dataOwnerID = extractedArgs[0]` — an unauthenticated, positional query argument. This PR removes the *email* conflation but not the *positional/unverified* one; that belongs to the owner-identity workstream (declare which argument identifies the owner + its namespace).

## Deployment Notes

Breaking wire-contract change: OE and CE must be deployed together. CE was already migrated (it dropped `ownerEmail`), so OE was the lagging side — this PR closes the gap. An old OE talking to the new CE (or the reverse) would mismatch on the consent-creation payload. CE's portal handler already gates approval on `consent.OwnerID != ownerSubject`, so after this sync both services agree on `OwnerID` as the canonical identifier.
