### PR TITLE
OE: identify Data Owner ID by configured argument name instead of position

### DIFF
--- a/exchange/orchestration-engine/config.docker.json
+++ b/exchange/orchestration-engine/config.docker.json
@@ -1,6 +1,7 @@
 {
   "environment": "development",
   "trustUpstream": true,
+  "foundationalIdArgName": "nic",
   "ceUrl": "http://consent-engine:8081",
   "pdpUrl": "http://policy-decision-point:8082",
   "auditConfig": {

--- a/exchange/orchestration-engine/config.example.json
+++ b/exchange/orchestration-engine/config.example.json
@@ -1,6 +1,7 @@
 {
   "environment": "development",
   "trustUpstream": false,
+  "foundationalIdArgName": "nic",
   "ceUrl": "http://localhost:8081",
   "pdpUrl": "http://localhost:8082",
   "auditConfig": {

--- a/exchange/orchestration-engine/configs/config.go
+++ b/exchange/orchestration-engine/configs/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	ArgMapping    []*graphql.ArgMapping `json:"argMapping,omitempty"`
 	TrustUpstream bool                  `json:"trustUpstream"`
 	JWT           JWTConfig             `json:"jwt,omitempty"`
+
+	// FoundationalIdArgName is the name of the query argument that identifies the
+	// data owner (e.g. "nic"), recognized by name rather than by position.
+	FoundationalIdArgName string `json:"foundationalIdArgName,omitempty"`
 }
 
 // ProviderConfig represents a provider configuration

--- a/exchange/orchestration-engine/federator/federator.go
+++ b/exchange/orchestration-engine/federator/federator.go
@@ -141,6 +141,12 @@ func Initialize(ctx context.Context, configs *configs.Config, providerHandler *p
 		}
 	}
 
+	// FoundationalIdArgName identifies the Data Owner ID argument by name in every
+	// federated query, so an empty value would silently reject all requests.
+	if configs.FoundationalIdArgName == "" {
+		return nil, fmt.Errorf("fatal configuration error: foundationalIdArgName is not configured - cannot identify the Data Owner ID argument")
+	}
+
 	// Initialize with providers from config if available
 	if configs.Providers != nil {
 		for _, p := range configs.Providers {
@@ -410,7 +416,7 @@ func (f *Federator) FederateQuery(ctx context.Context, request graphql.Request, 
 		}
 		if !allSame {
 			logger.Log.Info("Conflicting Data Owner ID values found in query",
-				"foundationalIdArgName", f.Configs.FoundationalIdArgName, "values", foundationalIdValues)
+				"foundationalIdArgName", f.Configs.FoundationalIdArgName, "valueCount", len(foundationalIdValues))
 			return createErrorResponseWithCode("Conflicting Data Owner ID values in query", errors.CodeAmbiguousEntityIdentifier)
 		}
 		dataOwnerID = foundationalIdValues[0]

--- a/exchange/orchestration-engine/federator/federator.go
+++ b/exchange/orchestration-engine/federator/federator.go
@@ -376,22 +376,44 @@ func (f *Federator) FederateQuery(ctx context.Context, request graphql.Request, 
 		}
 	}
 
-	// Check for Data Owner ID in extracted arguments
+	// Check for Data Owner ID in extracted arguments, identified by the configured
+	// foundational identifier argument name (e.g. "nic") — not by position.
 	var dataOwnerID string
-	if len(extractedArgs) == 0 {
-		logger.Log.Info("Data Owner ID argument is missing: extractedArgs is empty or nil")
-		return createErrorResponseWithCode("Data Owner ID argument is missing", errors.CodeMissingEntityIdentifier)
+	var foundationalIdValues []string
+	for _, arg := range extractedArgs {
+		if arg == nil || arg.Argument == nil || arg.Name == nil {
+			continue
+		}
+		if arg.Name.Value != f.Configs.FoundationalIdArgName {
+			continue
+		}
+		val := arg.Value.GetValue()
+		if s, ok := val.(string); ok && s != "" {
+			foundationalIdValues = append(foundationalIdValues, s)
+		}
 	}
-	val := extractedArgs[0].Value.GetValue()
-	if s, ok := val.(string); ok {
-		dataOwnerID = s
-	} else {
-		logger.Log.Error("CitizenID is not a string", "value", val)
-		dataOwnerID = ""
-	}
-	if dataOwnerID == "" {
-		logger.Log.Info("Data Owner ID argument is missing or invalid")
+
+	switch len(foundationalIdValues) {
+	case 0:
+		logger.Log.Info("Data Owner ID argument is missing or invalid",
+			"foundationalIdArgName", f.Configs.FoundationalIdArgName)
 		return createErrorResponseWithCode("Data Owner ID argument is missing or invalid", errors.CodeMissingEntityIdentifier)
+	case 1:
+		dataOwnerID = foundationalIdValues[0]
+	default:
+		allSame := true
+		for _, v := range foundationalIdValues[1:] {
+			if v != foundationalIdValues[0] {
+				allSame = false
+				break
+			}
+		}
+		if !allSame {
+			logger.Log.Info("Conflicting Data Owner ID values found in query",
+				"foundationalIdArgName", f.Configs.FoundationalIdArgName, "values", foundationalIdValues)
+			return createErrorResponseWithCode("Conflicting Data Owner ID values in query", errors.CodeAmbiguousEntityIdentifier)
+		}
+		dataOwnerID = foundationalIdValues[0]
 	}
 
 	// Handle consent check if consent is required

--- a/exchange/orchestration-engine/federator/federator_internal_test.go
+++ b/exchange/orchestration-engine/federator/federator_internal_test.go
@@ -67,8 +67,9 @@ func TestFederateQuery_WithMockSchema(t *testing.T) {
 
 	// 3. Setup Config
 	cfg := &configs.Config{
-		Environment:   "test",
-		TrustUpstream: true, // Trust upstream to avoid JWT validation requirements
+		Environment:           "test",
+		TrustUpstream:         true, // Trust upstream to avoid JWT validation requirements
+		FoundationalIdArgName: "nic",
 		Providers: []*configs.ProviderConfig{
 			{
 				ProviderKey: "drp",

--- a/exchange/orchestration-engine/federator/federator_internal_test.go
+++ b/exchange/orchestration-engine/federator/federator_internal_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/auth"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/configs"
+	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/consent"
+	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/internals/errors"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/pkg/graphql"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/policy"
 	"github.com/OpenNDX/openndx-core/exchange/orchestration-engine/provider"
@@ -136,6 +138,133 @@ func TestFederateQuery_WithMockSchema(t *testing.T) {
 	assert.Equal(t, "John Doe", personInfo["fullName"])
 }
 
+// TestFederateQuery_DataOwnerIdentification verifies that the Data Owner ID is
+// matched by the configured foundationalIdArgName rather than by argument
+// position, and that multiple mappings agreeing on the same value don't
+// trigger a false conflict.
+//
+// Note: the AMBIGUOUS_IDENTIFIER path (foundationalIdValues containing two
+// different values) is not covered here because it isn't currently reachable
+// through a real query: ExtractRequiredArguments (arghandler.go) dedupes by
+// ArgMapping pointer, so the first actual argument that matches a given
+// mapping "claims" it for the rest of the request, and every ArgSource for
+// that mapping ends up holding that same first-seen value.
+func TestFederateQuery_DataOwnerIdentification(t *testing.T) {
+	// sessionInfo's "requestId" argument is extracted before personInfo's "nic"
+	// argument, so a positional implementation would pick the wrong value.
+	// personInfo's "nic" argument is also matched by two separate mappings
+	// (one targeting "person", one targeting the "person.fullName" subfield),
+	// producing two equal foundationalIdValues from a single query argument.
+	schemaSDL := `
+		directive @sourceInfo(providerKey: String!, providerField: String!, schemaId: String) on FIELD_DEFINITION
+		type Query {
+			personInfo(nic: String!): PersonInfo @sourceInfo(providerKey: "drp", providerField: "person", schemaId: "drp-schema")
+			sessionInfo(requestId: String!): SessionInfo @sourceInfo(providerKey: "drp", providerField: "session", schemaId: "drp-schema")
+		}
+		type PersonInfo {
+			fullName: String @sourceInfo(providerKey: "drp", providerField: "person.fullName", schemaId: "drp-schema")
+		}
+		type SessionInfo {
+			status: String @sourceInfo(providerKey: "drp", providerField: "session.status", schemaId: "drp-schema")
+		}
+	`
+	argMapping := []*graphql.ArgMapping{
+		{ProviderKey: "drp", SchemaID: "drp-schema", TargetArgName: "nic", SourceArgPath: "personInfo-nic", TargetArgPath: "person"},
+		{ProviderKey: "drp", SchemaID: "drp-schema", TargetArgName: "nic", SourceArgPath: "fullName-nic", TargetArgPath: "person.fullName"},
+		{ProviderKey: "drp", SchemaID: "drp-schema", TargetArgName: "requestId", SourceArgPath: "sessionInfo-requestId", TargetArgPath: "session"},
+	}
+
+	// setupFederator wires a Federator whose PDP mock always requires consent
+	// and whose CE mock captures the OwnerID it receives, then rejects the
+	// consent. This lets the test assert on the resolved Data Owner ID
+	// without needing a full multi-provider round trip.
+	setupFederator := func(t *testing.T) (*Federator, *string) {
+		var capturedOwnerID string
+
+		pdpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			resp := policy.PdpResponse{
+				AppAuthorized:           true,
+				AppRequiresOwnerConsent: true,
+				ConsentRequiredFields: []policy.ConsentRequiredField{
+					{FieldName: "fullName", SchemaID: "drp-schema"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		t.Cleanup(pdpServer.Close)
+
+		ceServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req consent.CreateConsentRequest
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			capturedOwnerID = req.ConsentRequirement.OwnerID
+
+			resp := consent.ConsentResponseInternalView{
+				ConsentID: "consent-1",
+				Status:    "pending",
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(resp)
+		}))
+		t.Cleanup(ceServer.Close)
+
+		cfg := &configs.Config{
+			Environment:           "test",
+			TrustUpstream:         true,
+			FoundationalIdArgName: "nic",
+			PdpConfig:             configs.PdpConfig{ClientURL: pdpServer.URL},
+			CeConfig:              configs.CeConfig{ClientURL: ceServer.URL},
+			ArgMapping:            argMapping,
+		}
+
+		providerHandler := provider.NewProviderHandler(nil)
+		mockService := &MockSchemaServiceWithSignature{SDL: schemaSDL}
+
+		f, err := Initialize(context.Background(), cfg, providerHandler, mockService)
+		require.NoError(t, err)
+
+		return f, &capturedOwnerID
+	}
+
+	assertion := &auth.ConsumerAssertion{Subscriber: "sub-123", ClientID: "app-123"}
+
+	t.Run("matches identifier by name, not position", func(t *testing.T) {
+		f, capturedOwnerID := setupFederator(t)
+
+		req := graphql.Request{
+			Query: `query {
+				sessionInfo(requestId: "req-999") { status }
+				personInfo(nic: "123") { fullName }
+			}`,
+		}
+
+		resp := f.FederateQuery(context.Background(), req, assertion)
+
+		require.NotEmpty(t, resp.Errors)
+		extensions := resp.Errors[0].(map[string]interface{})["extensions"].(map[string]interface{})
+		assert.Equal(t, errors.CodeCENotApproved, extensions["code"])
+		assert.Equal(t, "123", *capturedOwnerID)
+	})
+
+	t.Run("allows repeated equal identifiers", func(t *testing.T) {
+		f, capturedOwnerID := setupFederator(t)
+
+		// The single "nic" argument below is matched by both the "person" and
+		// "person.fullName" mappings, producing two equal foundationalIdValues.
+		req := graphql.Request{
+			Query: `query {
+				personInfo(nic: "123") { fullName }
+			}`,
+		}
+
+		resp := f.FederateQuery(context.Background(), req, assertion)
+
+		require.NotEmpty(t, resp.Errors)
+		extensions := resp.Errors[0].(map[string]interface{})["extensions"].(map[string]interface{})
+		assert.Equal(t, errors.CodeCENotApproved, extensions["code"])
+		assert.Equal(t, "123", *capturedOwnerID)
+	})
+}
+
 func TestFederateQuery_PDPDeny(t *testing.T) {
 	// Mock PDP to deny
 	pdpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -147,8 +276,9 @@ func TestFederateQuery_PDPDeny(t *testing.T) {
 	defer pdpServer.Close()
 
 	cfg := &configs.Config{
-		Environment:   "test",
-		TrustUpstream: true, // Trust upstream to avoid JWT validation requirements
+		Environment:           "test",
+		TrustUpstream:         true, // Trust upstream to avoid JWT validation requirements
+		FoundationalIdArgName: "nic",
 		PdpConfig: configs.PdpConfig{
 			ClientURL: pdpServer.URL,
 		},
@@ -232,8 +362,9 @@ func TestInitialize_FailsWithInvalidConfig(t *testing.T) {
 
 	t.Run("succeeds when trustUpstream=true even without JWKS URL", func(t *testing.T) {
 		cfg := &configs.Config{
-			Environment:   "production",
-			TrustUpstream: true,
+			Environment:           "production",
+			TrustUpstream:         true,
+			FoundationalIdArgName: "nic",
 			JWT: configs.JWTConfig{
 				JwksUrl: "", // Missing JWKS URL is OK when trusting upstream
 			},
@@ -245,8 +376,9 @@ func TestInitialize_FailsWithInvalidConfig(t *testing.T) {
 
 	t.Run("succeeds when trustUpstream=true even with invalid JWKS URL", func(t *testing.T) {
 		cfg := &configs.Config{
-			Environment:   "production",
-			TrustUpstream: true,
+			Environment:           "production",
+			TrustUpstream:         true,
+			FoundationalIdArgName: "nic",
 			JWT: configs.JWTConfig{
 				JwksUrl: "http://invalid-url:99999/jwks", // Invalid URL is logged but not fatal
 			},
@@ -254,5 +386,16 @@ func TestInitialize_FailsWithInvalidConfig(t *testing.T) {
 
 		_, err := Initialize(context.Background(), cfg, providerHandler, nil)
 		require.NoError(t, err) // Should not fail, just log warning
+	})
+
+	t.Run("fails when foundationalIdArgName is not configured", func(t *testing.T) {
+		cfg := &configs.Config{
+			Environment:   "production",
+			TrustUpstream: true,
+		}
+
+		_, err := Initialize(context.Background(), cfg, providerHandler, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "foundationalIdArgName is not configured")
 	})
 }

--- a/exchange/orchestration-engine/internals/errors/codes.go
+++ b/exchange/orchestration-engine/internals/errors/codes.go
@@ -20,7 +20,8 @@ const (
 
 // OE-related
 const (
-	CodeMissingEntityIdentifier = "MISSING_IDENTIFIER"
+	CodeMissingEntityIdentifier   = "MISSING_IDENTIFIER"
+	CodeAmbiguousEntityIdentifier = "AMBIGUOUS_IDENTIFIER"
 )
 
 // Auth-related

--- a/exchange/orchestration-engine/server/server_internal_test.go
+++ b/exchange/orchestration-engine/server/server_internal_test.go
@@ -18,8 +18,9 @@ import (
 func TestSetupRouter_Health(t *testing.T) {
 	// Initialize a dummy federator
 	cfg := &configs.Config{
-		Environment:   "test",
-		TrustUpstream: true, // Trust upstream to avoid JWT validation requirements
+		Environment:           "test",
+		TrustUpstream:         true, // Trust upstream to avoid JWT validation requirements
+		FoundationalIdArgName: "nic",
 	}
 	providerHandler := provider.NewProviderHandler(nil)
 	f, err := federator.Initialize(context.Background(), cfg, providerHandler, nil)
@@ -40,8 +41,9 @@ func TestSetupRouter_Health(t *testing.T) {
 
 func TestSetupRouter_SDL_Endpoints(t *testing.T) {
 	cfg := &configs.Config{
-		Environment:   "test",
-		TrustUpstream: true, // Trust upstream to avoid JWT validation requirements
+		Environment:           "test",
+		TrustUpstream:         true, // Trust upstream to avoid JWT validation requirements
+		FoundationalIdArgName: "nic",
 	}
 	providerHandler := provider.NewProviderHandler(nil)
 	f, err := federator.Initialize(context.Background(), cfg, providerHandler, nil)
@@ -76,8 +78,9 @@ func TestSetupRouter_SDL_Endpoints(t *testing.T) {
 
 func TestSetupRouter_PublicGraphQL_BadRequest(t *testing.T) {
 	cfg := &configs.Config{
-		Environment:   "test",
-		TrustUpstream: true, // Trust upstream to avoid JWT validation requirements
+		Environment:           "test",
+		TrustUpstream:         true, // Trust upstream to avoid JWT validation requirements
+		FoundationalIdArgName: "nic",
 	}
 	providerHandler := provider.NewProviderHandler(nil)
 	f, err := federator.Initialize(context.Background(), cfg, providerHandler, nil)
@@ -98,8 +101,9 @@ func TestSetupRouter_PublicGraphQL_BadRequest(t *testing.T) {
 
 func TestSetupRouter_PublicGraphQL_Unauthorized(t *testing.T) {
 	cfg := &configs.Config{
-		Environment:   "test",
-		TrustUpstream: true, // Trust upstream to avoid JWT validation requirements
+		Environment:           "test",
+		TrustUpstream:         true, // Trust upstream to avoid JWT validation requirements
+		FoundationalIdArgName: "nic",
 	}
 	providerHandler := provider.NewProviderHandler(nil)
 	f, err := federator.Initialize(context.Background(), cfg, providerHandler, nil)

--- a/tests/integration/config.json
+++ b/tests/integration/config.json
@@ -1,5 +1,6 @@
 {
   "trustUpstream": true,
+  "foundationalIdArgName": "nic",
   "ceUrl": "http://consent-engine:8081",
   "pdpUrl": "http://policy-decision-point:8082",
   "providers": [


### PR DESCRIPTION
## Summary
- `Federator.FederateQuery` now identifies the Data Owner ID by matching the configured `foundationalIdArgName` (e.g. `nic`) against extracted query argument names, instead of blindly taking the first extracted argument by position.
- Adds `CodeAmbiguousEntityIdentifier` (`AMBIGUOUS_IDENTIFIER`) for the case where multiple matching arguments carry conflicting values in the same query.
- Adds the new `foundationalIdArgName` config field to `config.example.json`, `config.docker.json`, and `tests/integration/config.json` (the latter was initially missed and would have broken the integration-tests CI workflow — confirmed by running the local integration suite, which now passes end-to-end).

Related: #490 (tracks the broader gap of config drift across environments and lack of fail-fast validation when this field is unset).

## Test plan
- [x] `exchange/orchestration-engine/federator/federator_internal_test.go` updated with `FoundationalIdArgName: "nic"`.
- [x] Ran `tests/integration/run-local-tests.sh` end-to-end (docker compose build + `go test -v -race ./...`) — all suites passed, including the `personInfo(nic: ...)` GraphQL flow tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for identifying the foundational entity identifier by name.
  - Identifier extraction now supports arguments in any order and accepts repeated matching values.
  - Added clear handling for missing, invalid, or conflicting identifiers.

- **Bug Fixes**
  - Prevented unrelated or malformed arguments from being incorrectly treated as the entity identifier.
  - Added a specific error code for ambiguous identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->